### PR TITLE
Define calibrated GPIO clock models and fail-closed revision handling

### DIFF
--- a/WsprryPi-UI/data/operation.css
+++ b/WsprryPi-UI/data/operation.css
@@ -189,6 +189,10 @@
     grid-column: auto;
 }
 
+#gpio_frequency_correction_panel {
+    grid-column: 1 / -1;
+}
+
 .operation-panel--primary {
     background-color: color-mix(in srgb, var(--bs-primary) 7%, var(--bs-body-bg) 93%);
     border-color: color-mix(in srgb, var(--bs-primary) 18%, var(--bs-border-color) 82%);

--- a/WsprryPi-UI/data/site.js
+++ b/WsprryPi-UI/data/site.js
@@ -2170,6 +2170,25 @@ function normalizeRuntimeStatus(msg) {
         ? Number(msg.cw_active_char_index)
         : -1;
 
+    const normalizeCorrectionProvenance = (value) => {
+        const source = value && typeof value === "object" ? value : {};
+        return {
+            available: source.available === true,
+            active: source.active === true,
+            processorProfile: typeof source.processor_profile === "string" ? source.processor_profile : "",
+            selectedParent: typeof source.selected_parent === "string" ? source.selected_parent : "",
+            nominalRateHz: Number.isFinite(Number(source.nominal_rate_hz)) ? Number(source.nominal_rate_hz) : 0,
+            intrinsicPpm: Number.isFinite(Number(source.intrinsic_ppm)) ? Number(source.intrinsic_ppm) : 0,
+            selectedComponentPpm: Number.isFinite(Number(source.selected_component_ppm)) ? Number(source.selected_component_ppm) : 0,
+            conductedResidualPpm: Number.isFinite(Number(source.conducted_residual_ppm)) ? Number(source.conducted_residual_ppm) : 0,
+            finalPpm: Number.isFinite(Number(source.final_ppm)) ? Number(source.final_ppm) : 0,
+            correctionMode: typeof source.correction_mode === "string" ? source.correction_mode : "",
+            providerName: typeof source.provider_name === "string" ? source.provider_name : "",
+            providerSourceSignature: typeof source.provider_source_signature === "string" ? source.provider_source_signature : "",
+            providerSnapshotTime: typeof source.provider_snapshot_time === "string" ? source.provider_snapshot_time : "",
+            executionIdentity: typeof source.execution_identity === "string" ? source.execution_identity : ""
+        };
+    };
     return {
         eventState: typeof msg.state === "string" ? msg.state : "",
         txState:
@@ -2241,6 +2260,8 @@ function normalizeRuntimeStatus(msg) {
         frequencyEstimateAgeSeconds: Number.isFinite(Number(msg.frequency_estimate_age_seconds))
             ? Number(msg.frequency_estimate_age_seconds)
             : 0,
+        gpioCorrectionCandidate: normalizeCorrectionProvenance(msg.gpio_correction_candidate),
+        gpioCorrectionCommitted: normalizeCorrectionProvenance(msg.gpio_correction_committed),
         frameCallsign: typeof msg.frame_callsign === "string" ? msg.frame_callsign : "",
         frameLocator: typeof msg.frame_locator === "string" ? msg.frame_locator : "",
         cwMessage: typeof msg.cw_message === "string" ? msg.cw_message : "",
@@ -3045,25 +3066,31 @@ function renderGpioFrequencyCorrection(status) {
         return;
     }
 
-    const qualification = status.frequencyEstimateQualification || "unavailable";
-    const label = qualification.charAt(0).toUpperCase() + qualification.slice(1);
-    const provider = status.frequencyEstimateProvider || "No provider";
-    const estimate = status.frequencyEstimatePpm === null
-        ? "not available"
-        : `${status.frequencyEstimatePpm.toFixed(3)} PPM`;
-    valueNode.textContent = `${label} · ${status.effectiveGpioPpm.toFixed(3)} PPM effective`;
+    const formatProvenance = (label, value) => {
+        if (!value?.available) {
+            return `${label}: unavailable`;
+        }
+        const parent = value.nominalRateHz > 0
+            ? `${value.selectedParent} ${(value.nominalRateHz / 1e6).toFixed(0)} MHz`
+            : value.selectedParent;
+        const source = value.providerSourceSignature || value.providerName || "manual/zero";
+        const identity = value.executionIdentity ? ` · ${value.executionIdentity}` : "";
+        const active = value.active ? " · active" : "";
+        const residual = value.correctionMode === "fixed_manual"
+            ? `${value.conductedResidualPpm.toFixed(3)} residual configured, not applied`
+            : `${value.conductedResidualPpm.toFixed(3)} residual`;
+        return `${label}: ${value.processorProfile} · ${parent} · ` +
+            `${value.intrinsicPpm.toFixed(3)} intrinsic · ` +
+            `${value.selectedComponentPpm.toFixed(3)} selected · ` +
+            `${residual} · ${value.finalPpm.toFixed(3)} PPM final · ` +
+            `${source}${identity}${active}`;
+    };
 
-    const provenance = status.frequencyEstimateProvenance
-        ? ` · ${status.frequencyEstimateProvenance}`
-        : "";
-    const age = status.frequencyEstimatePpm === null
-        ? ""
-        : ` · Age ${Math.max(0, status.frequencyEstimateAgeSeconds).toFixed(0)} s`;
+    valueNode.textContent = formatProvenance(
+        "Candidate", status.gpioCorrectionCandidate);
     detailNode.textContent =
-        `${provider}${provenance} · Estimate ${estimate}${age} · ` +
-        `Residual ${status.gpioFrequencyResidualPpm.toFixed(3)} PPM · ` +
-        `Mode ${String(status.frequencyCorrectionMode || "uncalibrated").replaceAll("_", " ")}. ` +
-        `${status.frequencyEstimateReason || "Provider qualification is informational and is not RF calibration."}`;
+        `${formatProvenance("Committed", status.gpioCorrectionCommitted)}. ` +
+        "Candidate refreshes do not alter a committed transmission.";
 }
 
 function applyRuntimeStatus(msg) {

--- a/WsprryPi-UI/data/views/operation.php
+++ b/WsprryPi-UI/data/views/operation.php
@@ -102,12 +102,12 @@ require __DIR__ . '/../card_header.php';
                     </article>
 
                     <article class="operation-panel operation-panel--wide" id="gpio_frequency_correction_panel">
-                        <div class="operation-panel__label">GPIO frequency correction</div>
+                        <div class="operation-panel__label">GPIO correction provenance</div>
                         <div class="operation-panel__value operation-panel__value--wrap" id="gpio_frequency_correction_value" aria-live="polite" aria-atomic="true">
                             Runtime correction status is not available yet.
                         </div>
                         <div class="form-text" id="gpio_frequency_correction_detail">
-                            Provider qualification is informational; it does not by itself establish RF calibration.
+                            Candidate and committed execution values are reported separately.
                         </div>
                     </article>
                 </section>

--- a/docs/research/issue-412-legacy-gpio-constants-audit.md
+++ b/docs/research/issue-412-legacy-gpio-constants-audit.md
@@ -424,6 +424,24 @@ processor/parent selection does not consume that intrinsic component yet;
 that activation remains Phase 3. Each request continues to receive one frozen
 scalar, and invalid selection now blocks a new request before backend planning.
 
+### Phase 3 implementation status
+
+Phase 3 is implemented on the Issue 429 branch. The scheduler now commits an
+exact BCM2835, BCM2836/BCM2837, or BCM2711 processor profile and fails closed
+when no supported legacy identity is available. The backend uses the shared
+revision decoder, requires its detected processor to match the committed
+profile, and selects PLLD or the BCM2711 oscillator from the Phase 1 model
+before calculating corrected rates and divider words.
+
+The scheduler composes the intrinsic and selected-additional corrections once
+before request creation. BCM2835 therefore always includes its historical
+`-2.5 PPM`; later 500 MHz and both BCM2711 parent models retain their separate
+zero discovery baselines. The backend verifies and decomposes the frozen final
+scalar without reapplying the intrinsic component. The stranded constructor
+expression and fallback-to-generic-500-MHz behavior are removed. RP1 and
+Si5351 correction paths remain isolated. Expanded active status provenance is
+still Phase 4.
+
 1. **Freeze the model and measurement contract.** Define distinct BCM2835,
    BCM2836/BCM2837, and BCM2711 profiles; define BCM2711 PLLD and oscillator
    parents; define `D = P - S`; specify discovery, closure, sign-perturbation,

--- a/docs/research/issue-412-legacy-gpio-constants-audit.md
+++ b/docs/research/issue-412-legacy-gpio-constants-audit.md
@@ -390,6 +390,23 @@ run do not alter the frozen execution correction.
 
 ## Phased resolution path
 
+### Phase 1 implementation status
+
+Phase 1 is implemented on the Issue 429 branch as a hardware-independent
+clock-model and campaign-math boundary in
+`src/WSPR-Transmitter/src/legacy_gpio_clock_model.{hpp,cpp}`. It records the
+three distinct processor profiles, valid parent pairings, nominal rates,
+BCM2835's authoritative historical `-2.5 PPM` intrinsic difference, the three
+independent discovery baselines, `D = P - S`, the exact wspr5 inverse, and
+calibration-before-harmonic-division. A focused test target independently
+asserts those contracts and malformed-input rejection.
+
+This phase does not select a runtime processor or parent, compose production
+corrections, activate the BCM2835 intrinsic value in transmission planning,
+publish provenance, or authorize measurement activity. Those remain gated by
+Phases 2 through 6 below. The SDR equation remains campaign-only analysis and
+is not application configuration or production frequency-generation state.
+
 1. **Freeze the model and measurement contract.** Define distinct BCM2835,
    BCM2836/BCM2837, and BCM2711 profiles; define BCM2711 PLLD and oscillator
    parents; define `D = P - S`; specify discovery, closure, sign-perturbation,

--- a/docs/research/issue-412-legacy-gpio-constants-audit.md
+++ b/docs/research/issue-412-legacy-gpio-constants-audit.md
@@ -204,9 +204,11 @@ an unadjusted 500 MHz model. The current runtime therefore neither applies the
 historical correction to RPi1 nor exposes its provenance.
 
 Restore the correction as named BCM2835 profile data, always included when
-that exact profile is selected. Keep BCM2836/BCM2837 at zero intrinsic profile
-correction. Remove the constructor expression only after the value has been
-relocated without changing its historical meaning.
+that exact profile is selected. BCM2836/BCM2837 must not inherit it; their own
+intrinsic system-to-RF difference begins at zero for discovery and is promoted
+only through the accepted measurement procedure. Remove the constructor
+expression only after the BCM2835 value has been relocated without changing
+its historical meaning.
 
 ### L2: inconsistent CLI boundary behavior
 
@@ -230,8 +232,9 @@ Material gaps remain:
 - negative skew and age;
 - scheduler/backend profile disagreement;
 - active status versus committed correction;
-- proof that BCM2835 receives exactly `-2.5 PPM` intrinsic correction while
-  BCM2836, BCM2837, and BCM2711 receive zero;
+- proof that BCM2835 receives exactly `-2.5 PPM` while BCM2836, BCM2837, and
+  BCM2711 never inherit that value and receive only their own parent-specific
+  promoted `D`;
 - proof that intrinsic profile correction remains present with provider,
   manual, and uncalibrated-zero additional correction modes;
 - source-selection boundary and generated-frequency tests for both BCM2711
@@ -256,14 +259,16 @@ RP1 without evidence.
 
 ## Accepted frequency-generation model
 
-The implementation path shall use these intrinsic constants:
+The implementation path shall use an intrinsic system-to-RF difference for
+each processor/parent model. The historical BCM2835 value is fixed; constants
+for available hardware are derived by the conducted procedure below:
 
-| Processor profile | Parent | Nominal rate | Intrinsic profile correction | Evidence status |
+| Processor profile | Parent | Nominal rate | Intrinsic system-to-RF difference | Evidence status |
 |---|---|---:|---:|---|
 | BCM2835 / RPi1 | PLLD | 500 MHz | `-2.5 PPM` | Authoritative historical legacy model; no current device available |
-| BCM2836 / BCM2837 class, including Zero 2 W | PLLD | 500 MHz | `0 PPM` | Legacy model; Zero 2 W available for exclusion and RF validation |
-| BCM2711 / RPi4 | PLLD | 750 MHz | `0 PPM` | Maintained model; RPi4 available for RF validation |
-| BCM2711 / RPi4 | oscillator | 54 MHz | `0 PPM` | Maintained low-frequency fallback; RPi4 available for RF validation |
+| BCM2836 / BCM2837 class, including Zero 2 W | PLLD | 500 MHz | To be derived; zero is the discovery baseline | Legacy excludes the BCM2835 constant; Zero 2 W available as the accepted representative |
+| BCM2711 / RPi4 | PLLD | 750 MHz | To be derived; zero is the discovery baseline | RPi4 available as the accepted representative |
+| BCM2711 / RPi4 | oscillator | 54 MHz | To be derived independently; zero is the discovery baseline | Distinct RPi4 parent path available for validation |
 
 Intrinsic profile correction is part of frequency generation regardless of
 whether the operator selects a provider estimate, a manual alternative, or no
@@ -285,12 +290,58 @@ profile model unconditional. The implementation must not apply provider and
 manual values together. It must validate the final sum, freeze it for the
 bounded execution, and publish every component separately.
 
+### Deriving a transportable intrinsic difference
+
+The purpose of the empirical campaign is not to promote one board's absolute
+uncorrected clock error into a chipset constant. The target quantity is the
+stable difference between the RF parent-clock error and the simultaneous local
+system-clock estimate:
+
+```text
+S = frozen qualified NTP system-clock correction in PPM
+P = RF parent-clock error inferred from receiver-corrected carrier measurement
+D = intrinsic system-to-RF difference for the processor/parent model
+
+D = P - S
+```
+
+All three quantities use the current source-rate convention: positive means
+the relevant physical clock runs fast and would place an uncorrected carrier
+high; negative means it runs slow. Calculations may retain exact rate ratios,
+but reported and composed values use PPM and must declare rounding precision.
+
+The preferred discovery run applies `S` while the intrinsic and configured
+residuals are zero. After receiver correction is applied exactly once, the
+remaining signed carrier error directly estimates `D`. An equivalent analysis
+may measure `P` without correction and subtract the simultaneous frozen `S`,
+but the preferred run exercises the real provider-composition path.
+
+Every discovery requires a closure run. The second bounded transmission
+applies `S + D` and must move the receiver-corrected carrier to the requested
+frequency within the declared tolerance. Positive and negative perturbations
+must independently confirm the sign and prove that neither `S` nor `D` is
+applied twice.
+
+The representative-board assumption is explicit: the derived `D` is accepted
+as authoritative for that processor/parent model even though only one board is
+measured. It must not cross parent, processor, GPIO route, receiver/reference,
+or backend boundaries. BCM2711 PLLD and oscillator therefore produce separate
+constants from separate discovery and closure runs.
+
+The campaign must retain the exact NTP snapshot and qualification, source
+signature, selected parent and nominal rate, executable and source revision,
+requested fundamental and harmonic relationship, GPIO route, SDR identity,
+receiver correction, reference identity, temperature/time context, raw
+captures, repeated-frequency results, and final calculation. Provider changes
+during a run do not alter the frozen execution correction.
+
 ## Phased resolution path
 
-1. **Freeze the model contract.** Define distinct BCM2835, BCM2836/BCM2837,
-   and BCM2711 profiles; define BCM2711 PLLD and oscillator parents; name the
-   constants above; and independently bind their selection and composition in
-   hardware-free tests.
+1. **Freeze the model and measurement contract.** Define distinct BCM2835,
+   BCM2836/BCM2837, and BCM2711 profiles; define BCM2711 PLLD and oscillator
+   parents; define `D = P - S`; specify discovery, closure, sign-perturbation,
+   repetition, receiver-correction, and evidence rules; and independently bind
+   selection and composition in hardware-free tests.
 2. **Harden correction selection.** Validate provider metadata and the final
    composed value; remove inconsistent clamping; preserve provider/manual
    precedence; and prove one-time application and execution-level freezing.
@@ -302,15 +353,19 @@ bounded execution, and publish every component separately.
    including processor profile, parent, nominal rate, intrinsic correction,
    provider/manual component, conducted residual, final correction, and
    snapshot identity.
-5. **Validate the available legacy hardware.** On the Zero 2 W, prove the
-   BCM2835 residual is excluded from the later 500 MHz profile. On the RPi4,
-   validate both 750 MHz PLLD and 54 MHz oscillator generation, all frequencies
-   that select each parent, transition boundaries, positive/negative/zero
-   additional correction, bounded keyed modes, and cleanup. Hardware activity
-   requires separate explicit authorization and a predeclared conducted plan.
-6. **Close the evidence record.** Retain BCM2835 as historically authoritative
-   but not modern-hardware-revalidated; record route-specific Zero 2 W and RPi4
-   results without transferring them to BCM2835, RP1, Si5351, or another route.
+5. **Run NTP-relative discovery and closure on available legacy hardware.** On
+   the Zero 2 W, prove the BCM2835 residual is excluded, freeze qualified `S`,
+   derive the 500 MHz profile's `D`, and verify `S + D` by closure. On the RPi4,
+   independently derive and close `D` for both 750 MHz PLLD and 54 MHz
+   oscillator generation, covering all parent-selection regions, transition
+   boundaries, positive/negative perturbations, bounded keyed modes, and
+   cleanup. Hardware activity requires separate explicit authorization and a
+   predeclared conducted plan.
+6. **Promote and close the evidence record.** Promote a constant only after its
+   discovery and closure evidence passes. Retain BCM2835 as historically
+   authoritative but not modern-hardware-revalidated. Record Zero 2 W and RPi4
+   constants separately without transferring them to another processor,
+   parent, route, RP1, or Si5351.
 
 ## Unknowns and next gate
 

--- a/docs/research/issue-412-legacy-gpio-constants-audit.md
+++ b/docs/research/issue-412-legacy-gpio-constants-audit.md
@@ -439,8 +439,24 @@ before request creation. BCM2835 therefore always includes its historical
 zero discovery baselines. The backend verifies and decomposes the frozen final
 scalar without reapplying the intrinsic component. The stranded constructor
 expression and fallback-to-generic-500-MHz behavior are removed. RP1 and
-Si5351 correction paths remain isolated. Expanded active status provenance is
-still Phase 4.
+Si5351 correction paths remain isolated.
+
+### Phase 4 implementation status
+
+Phase 4 exposes separate current-candidate and committed-execution GPIO clock
+provenance through the runtime status API and Operation view. The candidate
+tracks the latest qualified selection, while the committed record freezes the
+processor profile, selected parent, nominal rate, intrinsic difference,
+selected provider or manual component, conducted residual, final correction,
+provider source signature and snapshot time, and a distinct execution identity
+at the scheduler-to-transmitter commit boundary. A later provider refresh does
+not rewrite the committed record, and active state is asserted only while the
+transmitter reports that it is transmitting. Cleanup clears the committed
+record rather than allowing stale execution provenance to survive.
+
+This reporting does not qualify RF accuracy or promote any discovery baseline.
+Physical discovery, closure, and constant promotion remain Phases 5 and 6 and
+require their separate authorization and evidence gates.
 
 1. **Freeze the model and measurement contract.** Define distinct BCM2835,
    BCM2836/BCM2837, and BCM2711 profiles; define BCM2711 PLLD and oscillator

--- a/docs/research/issue-412-legacy-gpio-constants-audit.md
+++ b/docs/research/issue-412-legacy-gpio-constants-audit.md
@@ -310,6 +310,57 @@ the relevant physical clock runs fast and would place an uncorrected carrier
 high; negative means it runs slow. Calculations may retain exact rate ratios,
 but reported and composed values use PPM and must declare rounding precision.
 
+### Campaign-only SDR calibration
+
+All discovery, perturbation, and closure analysis shall use this supplied SDR
+calibration:
+
+```text
+detected_frequency_hz - reference_frequency_hz =
+    0.4484 Hz + reference_frequency_hz * 1.01012 PPM
+```
+
+The exact inverse applied to every raw detected carrier is:
+
+```text
+calibrated_sdr_hz =
+    (raw_detected_sdr_hz - 0.4484 Hz)
+    / (1 + 1.01012 * 10^-6)
+
+calibrated_rf_error_hz = calibrated_sdr_hz - requested_rf_hz
+
+calibrated_rf_error_ppm =
+    calibrated_rf_error_hz / requested_rf_hz * 10^6
+```
+
+The inverse, rather than an approximate subtraction, is authoritative for
+these campaigns. The intercept and proportional term are applied exactly once
+before `P`, `D`, discovery error, closure error, or acceptance is calculated.
+Both the raw detected frequency and calibrated result must be retained.
+
+When the receiver observes a harmonic, calibration occurs at the raw detected
+harmonic frequency before translation to the transmitter fundamental:
+
+```text
+calibrated_harmonic_hz =
+    (raw_detected_harmonic_hz - 0.4484 Hz)
+    / (1 + 1.01012 * 10^-6)
+
+calibrated_fundamental_hz = calibrated_harmonic_hz / harmonic_number
+```
+
+Dividing before removing the affine intercept would scale the `0.4484 Hz`
+term incorrectly. The harmonic number and requested fundamental must be
+authenticated campaign inputs, not inferred from the nearest apparent tone.
+
+This calibration corrects the measurement instrument only. It is required
+campaign methodology and evidence metadata, but it must never become a
+WsprryPi runtime setting, chipset/parent constant, intrinsic `D`, provider
+residual, manual correction, configuration default, or production frequency
+calculation. It applies only to the SDR and receiver configuration for which
+the user declares it authoritative. Another receiver or changed configuration
+requires separately supplied calibration evidence.
+
 The preferred discovery run applies `S` while the intrinsic and configured
 residuals are zero. After receiver correction is applied exactly once, the
 remaining signed carrier error directly estimates `D`. An equivalent analysis
@@ -330,18 +381,23 @@ constants from separate discovery and closure runs.
 
 The campaign must retain the exact NTP snapshot and qualification, source
 signature, selected parent and nominal rate, executable and source revision,
-requested fundamental and harmonic relationship, GPIO route, SDR identity,
-receiver correction, reference identity, temperature/time context, raw
-captures, repeated-frequency results, and final calculation. Provider changes
-during a run do not alter the frozen execution correction.
+requested fundamental and authenticated harmonic relationship, GPIO route,
+SDR identity and configuration, the exact calibration equation, raw detected
+frequency, calibrated SDR frequency, receiver correction application count,
+reference identity, temperature/time context, raw captures,
+repeated-frequency results, and final calculation. Provider changes during a
+run do not alter the frozen execution correction.
 
 ## Phased resolution path
 
 1. **Freeze the model and measurement contract.** Define distinct BCM2835,
    BCM2836/BCM2837, and BCM2711 profiles; define BCM2711 PLLD and oscillator
    parents; define `D = P - S`; specify discovery, closure, sign-perturbation,
-   repetition, receiver-correction, and evidence rules; and independently bind
-   selection and composition in hardware-free tests.
+   repetition, SDR inverse-calibration, harmonic-ordering, one-time receiver
+   correction, and evidence rules; and independently bind selection and
+   composition in hardware-free tests. Measurement-analysis fixtures must use
+   known synthetic raw frequencies to prove the exact inverse and demonstrate
+   that calibration-before-harmonic-division is enforced.
 2. **Harden correction selection.** Validate provider metadata and the final
    composed value; remove inconsistent clamping; preserve provider/manual
    precedence; and prove one-time application and execution-level freezing.
@@ -359,13 +415,16 @@ during a run do not alter the frozen execution correction.
    independently derive and close `D` for both 750 MHz PLLD and 54 MHz
    oscillator generation, covering all parent-selection regions, transition
    boundaries, positive/negative perturbations, bounded keyed modes, and
-   cleanup. Hardware activity requires separate explicit authorization and a
-   predeclared conducted plan.
+   cleanup. Every result and acceptance decision uses the calibrated SDR value,
+   while retaining the raw detection. Hardware activity requires separate
+   explicit authorization and a predeclared conducted plan.
 6. **Promote and close the evidence record.** Promote a constant only after its
-   discovery and closure evidence passes. Retain BCM2835 as historically
-   authoritative but not modern-hardware-revalidated. Record Zero 2 W and RPi4
-   constants separately without transferring them to another processor,
-   parent, route, RP1, or Si5351.
+   calibrated discovery and calibrated closure evidence passes. Retain BCM2835
+   as historically authoritative but not modern-hardware-revalidated. Record
+   Zero 2 W and RPi4 constants separately without transferring them to another
+   processor, parent, route, RP1, or Si5351. Retain the SDR calibration as
+   evidence methodology only; do not promote it or any component of it into
+   WsprryPi production state.
 
 ## Unknowns and next gate
 

--- a/docs/research/issue-412-legacy-gpio-constants-audit.md
+++ b/docs/research/issue-412-legacy-gpio-constants-audit.md
@@ -267,8 +267,8 @@ for available hardware are derived by the conducted procedure below:
 |---|---|---:|---:|---|
 | BCM2835 / RPi1 | PLLD | 500 MHz | `-2.5 PPM` | Authoritative historical legacy model; no current device available |
 | BCM2836 / BCM2837 class, including Zero 2 W | PLLD | 500 MHz | To be derived; zero is the discovery baseline | Legacy excludes the BCM2835 constant; Zero 2 W available as the accepted representative |
-| BCM2711 / RPi4 | PLLD | 750 MHz | `+0.153768 PPM` | Promoted from the authorized GPIO20 conducted ten-band discovery on the representative RPi4 |
-| BCM2711 / RPi4 | oscillator | 54 MHz | `-15.035290 PPM` | Promoted from the authorized GPIO20 conducted 2200 m discovery and closure on the representative RPi4 |
+| BCM2711 / RPi4 | PLLD | 750 MHz | `0 PPM` | Conservative product baseline; nonzero conducted candidates were not stable against contemporaneous system-clock estimation and await GPS-referenced reassessment |
+| BCM2711 / RPi4 | oscillator | 54 MHz | `0 PPM` | Conservative product baseline; the former promoted value failed fresh GPSDO-bracketed closure and awaits GPS-referenced reassessment |
 
 Intrinsic profile correction is part of frequency generation regardless of
 whether the operator selects a provider estimate, a manual alternative, or no
@@ -436,8 +436,8 @@ before calculating corrected rates and divider words.
 The scheduler composes the intrinsic and selected-additional corrections once
 before request creation. BCM2835 therefore always includes its historical
 `-2.5 PPM`, while the later 500 MHz model retains its separate zero discovery
-baseline. The BCM2711 PLLD and oscillator models use their independently
-promoted conducted `+0.153768 PPM` and `-15.035290 PPM` intrinsic values. The
+baseline. Both BCM2711 parents use conservative zero baselines pending a
+GPS-referenced reassessment. The
 backend verifies and decomposes the frozen final scalar without reapplying the
 intrinsic component. The
 stranded constructor expression and fallback-to-generic-500-MHz behavior are
@@ -457,14 +457,16 @@ transmitter reports that it is transmitting. Cleanup clears the committed
 record rather than allowing stale execution provenance to survive.
 
 This reporting does not itself qualify RF accuracy or promote a discovery
-baseline. The BCM2711 PLLD value was subsequently promoted by operator
-direction from the authorized ten-band GPIO20 conducted discovery described
-below. Other physical discovery, closure, and constant promotion remain Phases
-5 and 6 and require their separate authorization and evidence gates.
+baseline. The earlier BCM2711 PLLD promotion was subsequently superseded by
+operator direction after repeated GPSDO-bracketed campaigns could not separate
+the PLLD residual from a changing network-derived system-clock estimate.
+BCM2711 PLLD therefore remains at zero until GPS-referenced reassessment.
+Other physical discovery, closure, and constant promotion remain Phases 5 and
+6 and require their separate authorization and evidence gates.
 
-### BCM2711 PLLD conducted promotion
+### BCM2711 PLLD conducted promotion (superseded)
 
-The promoted BCM2711 750 MHz PLLD intrinsic value is `+0.153768 PPM`. It was
+The former BCM2711 750 MHz PLLD intrinsic value was `+0.153768 PPM`. It was
 derived from one coherent conducted campaign on the representative Raspberry
 Pi 4 using GPIO20, a `-20 dB` conducted path, and SDRplay RSP1B serial
 `2404058C60`. Chrony supplied a qualified and frozen `S = 9.626 PPM` with a
@@ -479,15 +481,18 @@ An independent longer-window analysis agreed within `0.000426 PPM`. The raw
 captures and metadata are retained on the authorized acquisition host under
 `/home/pi/wsprrypi-phase5-plld-final-20260829`.
 
-This operator-directed promotion does not claim that closure or signed
-perturbation runs have passed. Those remain required before the broader Issue
-429 Phase 6 evidence record can be declared complete. The value does not apply
-to the distinct BCM2711 54 MHz oscillator parent or another processor, GPIO
-route, receiver, or backend.
+Later Issue 429 GPSDO-bracketed discovery, closure, repeatability, and short
+per-capture Chrony campaigns produced incompatible nonzero candidates because
+the network-derived system-clock estimate changed during and between runs.
+Operator direction therefore superseded the nonzero promotion with a
+conservative `0 PPM` product baseline until a GPS-referenced system-clock
+measurement is available. Neither the former value nor the zero baseline
+applies to the distinct BCM2711 54 MHz oscillator parent, another processor,
+GPIO route, receiver, or backend.
 
-### BCM2711 oscillator conducted promotion
+### BCM2711 oscillator conducted promotion (superseded)
 
-The promoted BCM2711 54 MHz oscillator intrinsic value is `-15.035290 PPM`.
+The former BCM2711 54 MHz oscillator intrinsic value was `-15.035290 PPM`.
 It was derived on the representative Raspberry Pi 4 at the 2200 m WSPR
 frequency using GPIO20, a `-20 dB` conducted path, and SDRplay RSP1B serial
 `2404058C60`. Chrony completed three qualified observations before RF work and
@@ -502,8 +507,14 @@ retained 3,500,000 samples with no timeout, overflow, or clipping and verified
 receiver cleanup. Evidence is retained on the acquisition host under
 `/home/pi/wsprrypi-phase5-oscillator-final-20260829/2200m`.
 
-This value is confined to the BCM2711 54 MHz oscillator parent. It does not
-apply to BCM2711 PLLD, another processor, GPIO route, receiver, or backend.
+Fresh Issue 429 GPSDO-bracketed closure repeated the former value three times
+and measured a consistent mean residual of `-2.213501 Hz` at 137500 Hz. An
+emulated same-board correction near `-31.25 PPM` closed within `0.019 Hz`, but
+is not demonstrated to transfer across Pi 4 boards. Operator direction
+therefore superseded the former promotion with a conservative `0 PPM` product
+baseline until GPS-referenced qualification is available. Neither historical
+value applies to BCM2711 PLLD, another processor, GPIO route, receiver, or
+backend.
 
 1. **Freeze the model and measurement contract.** Define distinct BCM2835,
    BCM2836/BCM2837, and BCM2711 profiles; define BCM2711 PLLD and oscillator

--- a/docs/research/issue-412-legacy-gpio-constants-audit.md
+++ b/docs/research/issue-412-legacy-gpio-constants-audit.md
@@ -268,7 +268,7 @@ for available hardware are derived by the conducted procedure below:
 | BCM2835 / RPi1 | PLLD | 500 MHz | `-2.5 PPM` | Authoritative historical legacy model; no current device available |
 | BCM2836 / BCM2837 class, including Zero 2 W | PLLD | 500 MHz | To be derived; zero is the discovery baseline | Legacy excludes the BCM2835 constant; Zero 2 W available as the accepted representative |
 | BCM2711 / RPi4 | PLLD | 750 MHz | `+0.153768 PPM` | Promoted from the authorized GPIO20 conducted ten-band discovery on the representative RPi4 |
-| BCM2711 / RPi4 | oscillator | 54 MHz | To be derived independently; zero is the discovery baseline | Distinct RPi4 parent path available for validation |
+| BCM2711 / RPi4 | oscillator | 54 MHz | `-15.035290 PPM` | Promoted from the authorized GPIO20 conducted 2200 m discovery and closure on the representative RPi4 |
 
 Intrinsic profile correction is part of frequency generation regardless of
 whether the operator selects a provider estimate, a manual alternative, or no
@@ -435,10 +435,11 @@ before calculating corrected rates and divider words.
 
 The scheduler composes the intrinsic and selected-additional corrections once
 before request creation. BCM2835 therefore always includes its historical
-`-2.5 PPM`; the later 500 MHz and BCM2711 oscillator models retain their
-separate zero discovery baselines. The BCM2711 PLLD model uses its promoted
-conducted `+0.153768 PPM` intrinsic value. The backend verifies and decomposes
-the frozen final scalar without reapplying the intrinsic component. The
+`-2.5 PPM`, while the later 500 MHz model retains its separate zero discovery
+baseline. The BCM2711 PLLD and oscillator models use their independently
+promoted conducted `+0.153768 PPM` and `-15.035290 PPM` intrinsic values. The
+backend verifies and decomposes the frozen final scalar without reapplying the
+intrinsic component. The
 stranded constructor expression and fallback-to-generic-500-MHz behavior are
 removed. RP1 and Si5351 correction paths remain isolated.
 
@@ -483,6 +484,26 @@ perturbation runs have passed. Those remain required before the broader Issue
 429 Phase 6 evidence record can be declared complete. The value does not apply
 to the distinct BCM2711 54 MHz oscillator parent or another processor, GPIO
 route, receiver, or backend.
+
+### BCM2711 oscillator conducted promotion
+
+The promoted BCM2711 54 MHz oscillator intrinsic value is `-15.035290 PPM`.
+It was derived on the representative Raspberry Pi 4 at the 2200 m WSPR
+frequency using GPIO20, a `-20 dB` conducted path, and SDRplay RSP1B serial
+`2404058C60`. Chrony completed three qualified observations before RF work and
+supplied the frozen discovery correction `S = 9.616 PPM`.
+
+Three independent discovery captures produced longer-window estimates of
+`-15.132360 PPM`, `-15.080798 PPM`, and `-15.055137 PPM`. Their mean candidate
+was closed, its remaining signed residual was used for one refinement, and a
+final closure at `-15.035290 PPM` measured `-0.005270 PPM` (`-0.000725 Hz`). A
+second estimator measured `-0.006791 PPM` (`-0.000934 Hz`). All five captures
+retained 3,500,000 samples with no timeout, overflow, or clipping and verified
+receiver cleanup. Evidence is retained on the acquisition host under
+`/home/pi/wsprrypi-phase5-oscillator-final-20260829/2200m`.
+
+This value is confined to the BCM2711 54 MHz oscillator parent. It does not
+apply to BCM2711 PLLD, another processor, GPIO route, receiver, or backend.
 
 1. **Freeze the model and measurement contract.** Define distinct BCM2835,
    BCM2836/BCM2837, and BCM2711 profiles; define BCM2711 PLLD and oscillator

--- a/docs/research/issue-412-legacy-gpio-constants-audit.md
+++ b/docs/research/issue-412-legacy-gpio-constants-audit.md
@@ -267,7 +267,7 @@ for available hardware are derived by the conducted procedure below:
 |---|---|---:|---:|---|
 | BCM2835 / RPi1 | PLLD | 500 MHz | `-2.5 PPM` | Authoritative historical legacy model; no current device available |
 | BCM2836 / BCM2837 class, including Zero 2 W | PLLD | 500 MHz | To be derived; zero is the discovery baseline | Legacy excludes the BCM2835 constant; Zero 2 W available as the accepted representative |
-| BCM2711 / RPi4 | PLLD | 750 MHz | To be derived; zero is the discovery baseline | RPi4 available as the accepted representative |
+| BCM2711 / RPi4 | PLLD | 750 MHz | `+0.153768 PPM` | Promoted from the authorized GPIO20 conducted ten-band discovery on the representative RPi4 |
 | BCM2711 / RPi4 | oscillator | 54 MHz | To be derived independently; zero is the discovery baseline | Distinct RPi4 parent path available for validation |
 
 Intrinsic profile correction is part of frequency generation regardless of
@@ -435,11 +435,12 @@ before calculating corrected rates and divider words.
 
 The scheduler composes the intrinsic and selected-additional corrections once
 before request creation. BCM2835 therefore always includes its historical
-`-2.5 PPM`; later 500 MHz and both BCM2711 parent models retain their separate
-zero discovery baselines. The backend verifies and decomposes the frozen final
-scalar without reapplying the intrinsic component. The stranded constructor
-expression and fallback-to-generic-500-MHz behavior are removed. RP1 and
-Si5351 correction paths remain isolated.
+`-2.5 PPM`; the later 500 MHz and BCM2711 oscillator models retain their
+separate zero discovery baselines. The BCM2711 PLLD model uses its promoted
+conducted `+0.153768 PPM` intrinsic value. The backend verifies and decomposes
+the frozen final scalar without reapplying the intrinsic component. The
+stranded constructor expression and fallback-to-generic-500-MHz behavior are
+removed. RP1 and Si5351 correction paths remain isolated.
 
 ### Phase 4 implementation status
 
@@ -454,9 +455,34 @@ not rewrite the committed record, and active state is asserted only while the
 transmitter reports that it is transmitting. Cleanup clears the committed
 record rather than allowing stale execution provenance to survive.
 
-This reporting does not qualify RF accuracy or promote any discovery baseline.
-Physical discovery, closure, and constant promotion remain Phases 5 and 6 and
-require their separate authorization and evidence gates.
+This reporting does not itself qualify RF accuracy or promote a discovery
+baseline. The BCM2711 PLLD value was subsequently promoted by operator
+direction from the authorized ten-band GPIO20 conducted discovery described
+below. Other physical discovery, closure, and constant promotion remain Phases
+5 and 6 and require their separate authorization and evidence gates.
+
+### BCM2711 PLLD conducted promotion
+
+The promoted BCM2711 750 MHz PLLD intrinsic value is `+0.153768 PPM`. It was
+derived from one coherent conducted campaign on the representative Raspberry
+Pi 4 using GPIO20, a `-20 dB` conducted path, and SDRplay RSP1B serial
+`2404058C60`. Chrony supplied a qualified and frozen `S = 9.626 PPM` with a
+stable four-source signature. The campaign covered 630 m, 160 m, 80 m, 60 m,
+40 m, 30 m, 20 m, 17 m, 15 m, and 10 m. Every capture retained 3,500,000
+samples with no timeout, overflow, or clipping and verified receiver cleanup.
+
+The receiver inverse calibration was applied exactly once. A proportional
+least-squares fit across all ten calibrated carrier errors produced
+`+0.153767747233 PPM`, rounded to six decimal places for the promoted model.
+An independent longer-window analysis agreed within `0.000426 PPM`. The raw
+captures and metadata are retained on the authorized acquisition host under
+`/home/pi/wsprrypi-phase5-plld-final-20260829`.
+
+This operator-directed promotion does not claim that closure or signed
+perturbation runs have passed. Those remain required before the broader Issue
+429 Phase 6 evidence record can be declared complete. The value does not apply
+to the distinct BCM2711 54 MHz oscillator parent or another processor, GPIO
+route, receiver, or backend.
 
 1. **Freeze the model and measurement contract.** Define distinct BCM2835,
    BCM2836/BCM2837, and BCM2711 profiles; define BCM2711 PLLD and oscillator

--- a/docs/research/issue-412-legacy-gpio-constants-audit.md
+++ b/docs/research/issue-412-legacy-gpio-constants-audit.md
@@ -407,6 +407,23 @@ publish provenance, or authorize measurement activity. Those remain gated by
 Phases 2 through 6 below. The SDR equation remains campaign-only analysis and
 is not application configuration or production frequency-generation state.
 
+### Phase 2 implementation status
+
+Phase 2 is implemented on the Issue 429 branch in the shared system-clock
+qualification and GPIO correction-selection boundary. Provider metadata now
+rejects negative or non-finite age, skew, and stability-span values; final
+qualified and stale provider-plus-residual sums are validated against the
+same `+/-200 PPM` contract as their inputs; invalid manual and residual values
+fail explicitly; and the compatibility CLI no longer clamps an out-of-range
+manual correction.
+
+The hardware-independent composition contract also validates intrinsic plus
+selected-additional correction and proves that the BCM2835 `-2.5 PPM`
+component survives provider, manual, and zero-additional modes. Runtime
+processor/parent selection does not consume that intrinsic component yet;
+that activation remains Phase 3. Each request continues to receive one frozen
+scalar, and invalid selection now blocks a new request before backend planning.
+
 1. **Freeze the model and measurement contract.** Define distinct BCM2835,
    BCM2836/BCM2837, and BCM2711 profiles; define BCM2711 PLLD and oscillator
    parents; define `D = P - S`; specify discovery, closure, sign-perturbation,

--- a/docs/research/issue-429-rp1-gpclk-zero-baseline.md
+++ b/docs/research/issue-429-rp1-gpclk-zero-baseline.md
@@ -1,0 +1,23 @@
+# Issue 429: RP1 GPCLK intrinsic zero baseline
+
+The Raspberry Pi 5 RP1 GPCLK profile uses an explicit intrinsic source-rate
+baseline of `0 PPM`. This is a conservative product baseline, not a conducted
+frequency-accuracy qualification or a claim that every RP1 clock has zero
+physical error.
+
+The scheduler manages RP1 with the same GPIO correction contract as the legacy
+GPIO backends. It composes this intrinsic baseline exactly once with either the
+selected qualified system-clock estimate plus configured conducted residual,
+or the selected manual PPM value. The resulting final correction is frozen in
+the execution request before the WSPR, TONE, or finite-event RP1 planner applies
+it to the explicit 200 MHz compatibility parent.
+
+A future nonzero intrinsic value requires separately authorized conducted
+discovery and closure, representative-hardware evidence, and an explicit
+promotion decision. It belongs in the RP1 intrinsic baseline; the existing
+GPIO Frequency Residual PPM setting remains the conducted residual used only
+with a qualified system-clock estimate.
+
+This value applies only to the Raspberry Pi 5 RP1 GPCLK backend. It does not
+apply to legacy BCM GPIO clocks, Si5351, another transmitter backend, receiver
+calibration, or a particular GPIO route.

--- a/src/Mailbox/README.md
+++ b/src/Mailbox/README.md
@@ -18,10 +18,13 @@ src/Mailbox/
     ├── bcm_model.hpp
     ├── mailbox.cpp
     ├── mailbox.hpp
+    ├── mailbox_revision.cpp
+    ├── mailbox_revision.hpp
     └── main.cpp
 ```
 
-`mailbox.hpp`, `mailbox.cpp`, and `bcm_model.hpp` form the reusable component.
+`mailbox.hpp`, `mailbox.cpp`, `mailbox_revision.hpp`, `mailbox_revision.cpp`, and
+`bcm_model.hpp` form the reusable component.
 `main.cpp` is an explicit live-device demonstration and is not an ordinary
 unit test.
 
@@ -31,6 +34,8 @@ unit test.
 - Compile-time page, block, bus-flag, and peripheral-base constants.
 - Big-endian parsing of `/proc/device-tree/soc/ranges` for peripheral-base
   discovery.
+- Fail-closed parsing of the Raspberry Pi `Revision` field used to select
+  mailbox memory-allocation flags; failed reads are not cached.
 - Exceptions instead of process termination on failures.
 - No dependency beyond the C++20 standard library and Linux kernel interfaces.
 
@@ -57,6 +62,7 @@ From the component source directory:
 cd src/Mailbox/src
 make debug
 make test
+make -C ../.. mailbox-memory-flag-test
 ```
 
 `make test` is deliberately hardware-free: it compiles the standalone demo but

--- a/src/Mailbox/src/mailbox.cpp
+++ b/src/Mailbox/src/mailbox.cpp
@@ -27,7 +27,6 @@
  */
 
 #include "mailbox.hpp"
-#include "bcm_model.hpp"
 
 // C++ Standard Library
 #include <array>
@@ -36,9 +35,9 @@
 #include <cstring>
 #include <fstream>
 #include <iterator>
-#include <vector>
 #include <optional>
 #include <system_error>
+#include <vector>
 
 // POSIX/system headers
 #include <endian.h> // for be32toh()
@@ -479,55 +478,20 @@ uint32_t Mailbox::discoverPeripheralBase()
 /**
  * @brief Determine the appropriate mailbox memory‐allocation flag for this Pi.
  *
- * Parses `/proc/cpuinfo` (cached on first call) to extract the hardware revision,
+ * Parses `/proc/cpuinfo` (cached after the first successful read) to extract
+ * the hardware revision,
  * maps that to a BCM processor ID, and then returns the correct
  * `MEM_FLAG_*` for `memAlloc()`:
  *   - BCM2835 (RPi1): non‐allocating L1 flag (0x0C)
  *   - BCM2836/37 (RPi2/3) and BCM2711 (RPi4): normal L2 alloc flag (0x04)
  *
  * @return The 32-bit flags value to pass to `memAlloc()`.
- * @throws std::runtime_error if the parsed processor ID is unrecognized.
+ * @throws std::runtime_error if the revision cannot be read or parsed, or if
+ *         the parsed processor ID is unrecognized.
  */
 uint32_t Mailbox::get_mem_flag()
 {
-    static std::optional<unsigned> cached_rev;
-    if (!cached_rev)
-    {
-        std::ifstream f("/proc/cpuinfo");
-        unsigned rev = 0;
-        if (f)
-        {
-            std::string line;
-            while (std::getline(f, line))
-            {
-                if (sscanf(line.c_str(), "Revision\t: %x", &rev) == 1)
-                {
-                    cached_rev = rev;
-                    break;
-                }
-            }
-        }
-        if (!cached_rev)
-            cached_rev = 0;
-    }
-
-    unsigned rev = *cached_rev;
-    BCMChip proc = (rev & 0x800000)
-                       ? static_cast<BCMChip>((rev & 0xF000) >> 12)
-                       : BCMChip::BCM_HOST_PROCESSOR_BCM2835;
-
-    switch (proc)
-    {
-    case BCMChip::BCM_HOST_PROCESSOR_BCM2835:
-        return 0x0C;
-    case BCMChip::BCM_HOST_PROCESSOR_BCM2836:
-    case BCMChip::BCM_HOST_PROCESSOR_BCM2837:
-    case BCMChip::BCM_HOST_PROCESSOR_BCM2711:
-        return 0x04;
-    }
-    throw std::runtime_error(
-        std::string("Mailbox::get_mem_flag(): unknown chipset ") +
-        std::string(to_string(proc)));
+    return revision_resolver_.memoryFlagFromCpuInfo("/proc/cpuinfo");
 }
 
 /**

--- a/src/Mailbox/src/mailbox.hpp
+++ b/src/Mailbox/src/mailbox.hpp
@@ -37,6 +37,8 @@
 #include <stdexcept>
 #include <vector>
 
+#include "mailbox_revision.hpp"
+
 // POSIX/system headers
 #include <linux/ioctl.h> // for IOCTL_MBOX_PROPERTY
 
@@ -165,6 +167,7 @@ private:
     static inline constexpr char MEM_FILE_NAME[] = "/dev/mem";
 
     int fd_ = -1;
+    mailbox_detail::RevisionResolver revision_resolver_;
 
     [[nodiscard]] uint32_t get_mem_flag();
 

--- a/src/Mailbox/src/mailbox_revision.cpp
+++ b/src/Mailbox/src/mailbox_revision.cpp
@@ -1,0 +1,91 @@
+#include "mailbox_revision.hpp"
+
+#include "bcm_model.hpp"
+
+#include <charconv>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+namespace mailbox_detail
+{
+    uint32_t RevisionResolver::memoryFlagFromCpuInfo(const char *path)
+    {
+        if (!cached_revision_)
+            cached_revision_ = readRevision(path);
+
+        return memoryFlagFromRevision(*cached_revision_);
+    }
+
+    uint32_t RevisionResolver::readRevision(const char *path)
+    {
+        std::ifstream input(path);
+        if (!input)
+        {
+            throw std::runtime_error(
+                std::string("Mailbox::get_mem_flag(): cannot open ") + path);
+        }
+
+        const auto trim = [](std::string_view value) {
+            const auto first = value.find_first_not_of(" \t\r\n");
+            if (first == std::string_view::npos)
+                return std::string_view{};
+            const auto last = value.find_last_not_of(" \t\r\n");
+            return value.substr(first, last - first + 1);
+        };
+
+        std::string line;
+        while (std::getline(input, line))
+        {
+            const auto colon = line.find(':');
+            if (colon == std::string::npos ||
+                trim(std::string_view(line).substr(0, colon)) != "Revision")
+            {
+                continue;
+            }
+
+            const auto value = trim(std::string_view(line).substr(colon + 1));
+            uint32_t revision = 0;
+            const auto result = std::from_chars(
+                value.data(), value.data() + value.size(), revision, 16);
+            if (value.empty() || result.ec != std::errc{} ||
+                result.ptr != value.data() + value.size())
+            {
+                throw std::runtime_error(
+                    std::string("Mailbox::get_mem_flag(): invalid Revision in ") + path);
+            }
+            return revision;
+        }
+
+        if (input.bad())
+        {
+            throw std::runtime_error(
+                std::string("Mailbox::get_mem_flag(): cannot read ") + path);
+        }
+
+        throw std::runtime_error(
+            std::string("Mailbox::get_mem_flag(): Revision not found in ") + path);
+    }
+
+    uint32_t RevisionResolver::memoryFlagFromRevision(uint32_t revision)
+    {
+        const BCMChip processor = (revision & 0x800000U)
+                                      ? static_cast<BCMChip>((revision & 0xF000U) >> 12U)
+                                      : BCMChip::BCM_HOST_PROCESSOR_BCM2835;
+
+        switch (processor)
+        {
+        case BCMChip::BCM_HOST_PROCESSOR_BCM2835:
+            return 0x0C;
+        case BCMChip::BCM_HOST_PROCESSOR_BCM2836:
+        case BCMChip::BCM_HOST_PROCESSOR_BCM2837:
+        case BCMChip::BCM_HOST_PROCESSOR_BCM2711:
+            return 0x04;
+        }
+        throw std::runtime_error(
+            std::string("Mailbox::get_mem_flag(): unknown chipset ") +
+            std::string(to_string(processor)));
+    }
+}

--- a/src/Mailbox/src/mailbox_revision.hpp
+++ b/src/Mailbox/src/mailbox_revision.hpp
@@ -1,0 +1,23 @@
+#ifndef MAILBOX_REVISION_HPP
+#define MAILBOX_REVISION_HPP
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+namespace mailbox_detail
+{
+    class RevisionResolver
+    {
+    public:
+        [[nodiscard]] uint32_t memoryFlagFromCpuInfo(const char *path);
+
+    private:
+        [[nodiscard]] static uint32_t readRevision(const char *path);
+        [[nodiscard]] static uint32_t memoryFlagFromRevision(uint32_t revision);
+
+        std::optional<uint32_t> cached_revision_;
+    };
+}
+
+#endif // MAILBOX_REVISION_HPP

--- a/src/Makefile
+++ b/src/Makefile
@@ -1217,7 +1217,7 @@ legacy-gpio-clock-model-test: $(BIN_DIR)/$(LEGACY_GPIO_CLOCK_MODEL_TEST_OUT)
 	$(Q)echo "Running hardware-independent legacy GPIO clock-model tests."
 	$(Q)./$(BIN_DIR)/$(LEGACY_GPIO_CLOCK_MODEL_TEST_OUT)
 
-$(BIN_DIR)/$(GPIO_FREQUENCY_CORRECTION_TEST_OUT): tests/gpio_frequency_correction_test.cpp system_clock_frequency_estimate.cpp
+$(BIN_DIR)/$(GPIO_FREQUENCY_CORRECTION_TEST_OUT): tests/gpio_frequency_correction_test.cpp system_clock_frequency_estimate.cpp WSPR-Transmitter/src/legacy_gpio_clock_model.cpp
 	$(Q)mkdir -p $(BIN_DIR)
 	$(Q)$(CXX) $(GPIO_FREQUENCY_CORRECTION_TEST_FLAGS) $^ -o $@
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -117,6 +117,8 @@ TEST_OUT := $(strip $(EXE_NAME)_debug)
 SEMANTICS_TEST_OUT := dial_frequency_semantics_test
 LEGACY_GPIO_CLOCK_MODEL_TEST_OUT := legacy_gpio_clock_model_test
 LEGACY_GPIO_CLOCK_MODEL_TEST_FLAGS = $(filter-out -fmax-errors=10,$(CXX_DEBUG_FLAGS))
+MAILBOX_MEMORY_FLAG_TEST_OUT := mailbox_memory_flag_test
+MAILBOX_MEMORY_FLAG_TEST_FLAGS = $(filter-out -fmax-errors=10,$(CXX_DEBUG_FLAGS))
 GPIO_FREQUENCY_CORRECTION_TEST_OUT := gpio_frequency_correction_test
 GPIO_FREQUENCY_CORRECTION_TEST_FLAGS = $(filter-out -fmax-errors=10,$(CXX_DEBUG_FLAGS))
 UI_SOURCE_REGRESSION_TEST_OUT := ui_source_regression_test
@@ -1105,7 +1107,7 @@ $(BIN_DIR)/$(OUT): $(PROFILE_RELEASE_BIN) FORCE_PROFILE_BINARY
 # ─────────────────────────────────────────────────────────────────────────────
 
 .PHONY: clean debug test test-tone test-oneshot install-binary FORCE_PROFILE_BINARY
-.PHONY: semantics-test legacy-gpio-clock-model-test gpio-frequency-correction-test machine-power-control-test websocket-lifecycle-test wspr-band-catalog-test gpio-band-policy-test
+.PHONY: semantics-test mailbox-memory-flag-test legacy-gpio-clock-model-test gpio-frequency-correction-test machine-power-control-test websocket-lifecycle-test wspr-band-catalog-test gpio-band-policy-test
 .PHONY: support-request-guard-test privileged-network-policy-test backend-http-guard-test websocket-upgrade-guard-test apache-privileged-network-policy-test privileged-network-transaction-test privileged-network-runtime-test privileged-network-runtime-wiring-test privileged-network-admin-test support-bundle-job-manager-test support-bundle-result-validator-test
 .PHONY: support-bundle-collector-executor-test support-bundle-runtime-test support-bundle-runtime-installer-test
 .PHONY: installer-dependency-test ui-publication-test support-bundle-age-dependency-test support-bundle-http-test support-bundle-web-server-wiring-test
@@ -1193,7 +1195,7 @@ test-oneshot: debug
 	$(Q)echo "Running test oneshot with sudo privileges."
 	$(Q)$(SUDO) ./$(BIN_DIR)/$(TEST_OUT) -D -x 1 $(WSPR_PARAMS)
 
-semantics-test: legacy-gpio-clock-model-test gpio-frequency-correction-test $(BIN_DIR)/$(SEMANTICS_TEST_OUT) $(BIN_DIR)/$(CLEANUP_LIFECYCLE_TEST_OUT) $(BIN_DIR)/$(UI_SOURCE_REGRESSION_TEST_OUT) $(BIN_DIR)/$(GPIO_BAND_POLICY_TEST_OUT)
+semantics-test: mailbox-memory-flag-test legacy-gpio-clock-model-test gpio-frequency-correction-test $(BIN_DIR)/$(SEMANTICS_TEST_OUT) $(BIN_DIR)/$(CLEANUP_LIFECYCLE_TEST_OUT) $(BIN_DIR)/$(UI_SOURCE_REGRESSION_TEST_OUT) $(BIN_DIR)/$(GPIO_BAND_POLICY_TEST_OUT)
 	$(Q)echo "Running runtime semantics tests."
 	$(Q)./$(BIN_DIR)/$(SEMANTICS_TEST_OUT)
 	$(Q)echo "Running cleanup lifecycle tests."
@@ -1216,6 +1218,14 @@ $(BIN_DIR)/$(LEGACY_GPIO_CLOCK_MODEL_TEST_OUT): WSPR-Transmitter/src/legacy_gpio
 legacy-gpio-clock-model-test: $(BIN_DIR)/$(LEGACY_GPIO_CLOCK_MODEL_TEST_OUT)
 	$(Q)echo "Running hardware-independent legacy GPIO clock-model tests."
 	$(Q)./$(BIN_DIR)/$(LEGACY_GPIO_CLOCK_MODEL_TEST_OUT)
+
+$(BIN_DIR)/$(MAILBOX_MEMORY_FLAG_TEST_OUT): tests/mailbox_memory_flag_test.cpp Mailbox/src/mailbox_revision.cpp
+	$(Q)mkdir -p $(BIN_DIR)
+	$(Q)$(CXX) $(MAILBOX_MEMORY_FLAG_TEST_FLAGS) $^ -o $@
+
+mailbox-memory-flag-test: $(BIN_DIR)/$(MAILBOX_MEMORY_FLAG_TEST_OUT)
+	$(Q)echo "Running mailbox memory flag tests."
+	$(Q)./$(BIN_DIR)/$(MAILBOX_MEMORY_FLAG_TEST_OUT)
 
 $(BIN_DIR)/$(GPIO_FREQUENCY_CORRECTION_TEST_OUT): tests/gpio_frequency_correction_test.cpp system_clock_frequency_estimate.cpp WSPR-Transmitter/src/legacy_gpio_clock_model.cpp
 	$(Q)mkdir -p $(BIN_DIR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -115,6 +115,8 @@ EXE_NAME := $(shell echo $(PRJ) | tr '[:upper:]' '[:lower:]')
 OUT := $(strip $(EXE_NAME))
 TEST_OUT := $(strip $(EXE_NAME)_debug)
 SEMANTICS_TEST_OUT := dial_frequency_semantics_test
+LEGACY_GPIO_CLOCK_MODEL_TEST_OUT := legacy_gpio_clock_model_test
+LEGACY_GPIO_CLOCK_MODEL_TEST_FLAGS = $(filter-out -fmax-errors=10,$(CXX_DEBUG_FLAGS))
 UI_SOURCE_REGRESSION_TEST_OUT := ui_source_regression_test
 GUARDED_MODE_CHANGE_PERSISTENCE_TEST_OUT := guarded_mode_change_persistence_test
 BAND_GPIO_DEFAULT_CONVERGENCE_TEST_OUT := band_gpio_default_convergence_test
@@ -278,6 +280,7 @@ SI5351_TEST_SOURCE := ./WSPR-Transmitter/src/si5351_backend_harness.cpp
 SI5351_PLANNER_TEST_SOURCE := ./WSPR-Transmitter/src/si5351_planner_test.cpp
 SI5351_TRANSITION_TEST_SOURCE := ./WSPR-Transmitter/src/si5351_transition_test.cpp
 STARTUP_QUIESCE_TEST_SOURCE := ./WSPR-Transmitter/src/startup_quiesce_test.cpp
+LEGACY_GPIO_CLOCK_MODEL_TEST_SOURCE := ./WSPR-Transmitter/src/legacy_gpio_clock_model_test.cpp
 SI5351_QUALIFICATION_SOURCE := ./WSPR-Transmitter/src/si5351_startup_quiesce_qualification.cpp
 SI5351_QUALIFICATION_MAIN_SOURCE := ./WSPR-Transmitter/src/si5351_startup_quiesce_qualification_main.cpp
 SI5351_QUALIFICATION_TEST_SOURCE := ./WSPR-Transmitter/src/si5351_startup_quiesce_qualification_test.cpp
@@ -293,7 +296,7 @@ SIMULATED_BACKEND_TEST_SOURCE := ./WSPR-Transmitter/src/simulated_transmit_backe
 SIMULATED_BACKEND_REALTIME_TEST_SOURCE := ./WSPR-Transmitter/src/simulated_transmit_backend_realtime_test.cpp
 TRANSMISSION_CONTROLLER_CONTRACT_TEST_SOURCE := ./WSPR-Transmitter/src/transmission_controller_contract_test.cpp
 THREAD_AFFINITY_UNAVAILABLE_TEST_SOURCE := ./WSPR-Transmitter/src/thread_affinity_unavailable_test.cpp
-COMPONENT_CPP_SOURCES := $(filter-out $(PPM_MANAGER_TEST_SOURCE) $(SIGNAL_HANDLER_TEST_SOURCE) $(SINGLETON_TEST_SOURCE) $(SI5351_TEST_SOURCE) $(SI5351_PLANNER_TEST_SOURCE) $(SI5351_TRANSITION_TEST_SOURCE) $(STARTUP_QUIESCE_TEST_SOURCE) $(SI5351_QUALIFICATION_SOURCE) $(SI5351_QUALIFICATION_MAIN_SOURCE) $(SI5351_QUALIFICATION_TEST_SOURCE) $(RP1_GPCLK_PLANNER_TEST_SOURCE) $(RP1_GPCLK_LIFECYCLE_TEST_SOURCE) $(RP1_GPCLK_TRANSITION_TEST_SOURCE) $(RP1_GPCLK_BACKEND_TEST_SOURCE) $(RP1_GPCLK_LINUX_PROVIDER_TEST_SOURCE) $(RP1_GPCLK_DEVELOPMENT_POLICY_TEST_SOURCE) $(RP1_GPCLK_TRANSMIT_BACKEND_TEST_SOURCE) $(RP1_GPCLK_ADMIN_PROBE_SOURCE) $(SIMULATED_BACKEND_TEST_SOURCE) $(SIMULATED_BACKEND_REALTIME_TEST_SOURCE) $(TRANSMISSION_CONTROLLER_CONTRACT_TEST_SOURCE) $(THREAD_AFFINITY_UNAVAILABLE_TEST_SOURCE),$(COMPONENT_CPP_SOURCES))
+COMPONENT_CPP_SOURCES := $(filter-out $(PPM_MANAGER_TEST_SOURCE) $(SIGNAL_HANDLER_TEST_SOURCE) $(SINGLETON_TEST_SOURCE) $(SI5351_TEST_SOURCE) $(SI5351_PLANNER_TEST_SOURCE) $(SI5351_TRANSITION_TEST_SOURCE) $(STARTUP_QUIESCE_TEST_SOURCE) $(LEGACY_GPIO_CLOCK_MODEL_TEST_SOURCE) $(SI5351_QUALIFICATION_SOURCE) $(SI5351_QUALIFICATION_MAIN_SOURCE) $(SI5351_QUALIFICATION_TEST_SOURCE) $(RP1_GPCLK_PLANNER_TEST_SOURCE) $(RP1_GPCLK_LIFECYCLE_TEST_SOURCE) $(RP1_GPCLK_TRANSITION_TEST_SOURCE) $(RP1_GPCLK_BACKEND_TEST_SOURCE) $(RP1_GPCLK_LINUX_PROVIDER_TEST_SOURCE) $(RP1_GPCLK_DEVELOPMENT_POLICY_TEST_SOURCE) $(RP1_GPCLK_TRANSMIT_BACKEND_TEST_SOURCE) $(RP1_GPCLK_ADMIN_PROBE_SOURCE) $(SIMULATED_BACKEND_TEST_SOURCE) $(SIMULATED_BACKEND_REALTIME_TEST_SOURCE) $(TRANSMISSION_CONTROLLER_CONTRACT_TEST_SOURCE) $(THREAD_AFFINITY_UNAVAILABLE_TEST_SOURCE),$(COMPONENT_CPP_SOURCES))
 COMPONENT_CPP_SOURCES := $(filter-out $(TRANSMITTER_SHARED_CPP_SOURCES) $(TRANSMITTER_BACKEND_CPP_SOURCES),$(COMPONENT_CPP_SOURCES))
 
 CPP_SOURCES := $(LOCAL_CPP_SOURCES) $(COMPONENT_CPP_SOURCES) $(TRANSMITTER_SHARED_CPP_SOURCES) $(SELECTED_BACKEND_CPP_SOURCES)
@@ -1099,7 +1102,7 @@ $(BIN_DIR)/$(OUT): $(PROFILE_RELEASE_BIN) FORCE_PROFILE_BINARY
 # ─────────────────────────────────────────────────────────────────────────────
 
 .PHONY: clean debug test test-tone test-oneshot install-binary FORCE_PROFILE_BINARY
-.PHONY: semantics-test machine-power-control-test websocket-lifecycle-test wspr-band-catalog-test gpio-band-policy-test
+.PHONY: semantics-test legacy-gpio-clock-model-test machine-power-control-test websocket-lifecycle-test wspr-band-catalog-test gpio-band-policy-test
 .PHONY: support-request-guard-test privileged-network-policy-test backend-http-guard-test websocket-upgrade-guard-test apache-privileged-network-policy-test privileged-network-transaction-test privileged-network-runtime-test privileged-network-runtime-wiring-test privileged-network-admin-test support-bundle-job-manager-test support-bundle-result-validator-test
 .PHONY: support-bundle-collector-executor-test support-bundle-runtime-test support-bundle-runtime-installer-test
 .PHONY: installer-dependency-test ui-publication-test support-bundle-age-dependency-test support-bundle-http-test support-bundle-web-server-wiring-test
@@ -1187,7 +1190,7 @@ test-oneshot: debug
 	$(Q)echo "Running test oneshot with sudo privileges."
 	$(Q)$(SUDO) ./$(BIN_DIR)/$(TEST_OUT) -D -x 1 $(WSPR_PARAMS)
 
-semantics-test: $(BIN_DIR)/$(SEMANTICS_TEST_OUT) $(BIN_DIR)/$(CLEANUP_LIFECYCLE_TEST_OUT) $(BIN_DIR)/$(UI_SOURCE_REGRESSION_TEST_OUT) $(BIN_DIR)/$(GPIO_BAND_POLICY_TEST_OUT)
+semantics-test: legacy-gpio-clock-model-test $(BIN_DIR)/$(SEMANTICS_TEST_OUT) $(BIN_DIR)/$(CLEANUP_LIFECYCLE_TEST_OUT) $(BIN_DIR)/$(UI_SOURCE_REGRESSION_TEST_OUT) $(BIN_DIR)/$(GPIO_BAND_POLICY_TEST_OUT)
 	$(Q)echo "Running runtime semantics tests."
 	$(Q)./$(BIN_DIR)/$(SEMANTICS_TEST_OUT)
 	$(Q)echo "Running cleanup lifecycle tests."
@@ -1202,6 +1205,14 @@ semantics-test: $(BIN_DIR)/$(SEMANTICS_TEST_OUT) $(BIN_DIR)/$(CLEANUP_LIFECYCLE_
 	$(Q)node tests/update_check_comparison_test.js
 	$(Q)echo "Running coherent UI publication tests."
 	$(Q)python3 ../scripts/tests/ui_publication_test.py
+
+$(BIN_DIR)/$(LEGACY_GPIO_CLOCK_MODEL_TEST_OUT): WSPR-Transmitter/src/legacy_gpio_clock_model_test.cpp WSPR-Transmitter/src/legacy_gpio_clock_model.cpp
+	$(Q)mkdir -p $(BIN_DIR)
+	$(Q)$(CXX) $(LEGACY_GPIO_CLOCK_MODEL_TEST_FLAGS) $^ -o $@
+
+legacy-gpio-clock-model-test: $(BIN_DIR)/$(LEGACY_GPIO_CLOCK_MODEL_TEST_OUT)
+	$(Q)echo "Running hardware-independent legacy GPIO clock-model tests."
+	$(Q)./$(BIN_DIR)/$(LEGACY_GPIO_CLOCK_MODEL_TEST_OUT)
 
 websocket-lifecycle-test: $(BIN_DIR)/$(WEBSOCKET_LIFECYCLE_TEST_OUT)
 	$(Q)./$(BIN_DIR)/$(WEBSOCKET_LIFECYCLE_TEST_OUT)

--- a/src/Makefile
+++ b/src/Makefile
@@ -117,6 +117,8 @@ TEST_OUT := $(strip $(EXE_NAME)_debug)
 SEMANTICS_TEST_OUT := dial_frequency_semantics_test
 LEGACY_GPIO_CLOCK_MODEL_TEST_OUT := legacy_gpio_clock_model_test
 LEGACY_GPIO_CLOCK_MODEL_TEST_FLAGS = $(filter-out -fmax-errors=10,$(CXX_DEBUG_FLAGS))
+GPIO_FREQUENCY_CORRECTION_TEST_OUT := gpio_frequency_correction_test
+GPIO_FREQUENCY_CORRECTION_TEST_FLAGS = $(filter-out -fmax-errors=10,$(CXX_DEBUG_FLAGS))
 UI_SOURCE_REGRESSION_TEST_OUT := ui_source_regression_test
 GUARDED_MODE_CHANGE_PERSISTENCE_TEST_OUT := guarded_mode_change_persistence_test
 BAND_GPIO_DEFAULT_CONVERGENCE_TEST_OUT := band_gpio_default_convergence_test
@@ -281,6 +283,7 @@ SI5351_PLANNER_TEST_SOURCE := ./WSPR-Transmitter/src/si5351_planner_test.cpp
 SI5351_TRANSITION_TEST_SOURCE := ./WSPR-Transmitter/src/si5351_transition_test.cpp
 STARTUP_QUIESCE_TEST_SOURCE := ./WSPR-Transmitter/src/startup_quiesce_test.cpp
 LEGACY_GPIO_CLOCK_MODEL_TEST_SOURCE := ./WSPR-Transmitter/src/legacy_gpio_clock_model_test.cpp
+GPIO_FREQUENCY_CORRECTION_TEST_SOURCE := ./tests/gpio_frequency_correction_test.cpp
 SI5351_QUALIFICATION_SOURCE := ./WSPR-Transmitter/src/si5351_startup_quiesce_qualification.cpp
 SI5351_QUALIFICATION_MAIN_SOURCE := ./WSPR-Transmitter/src/si5351_startup_quiesce_qualification_main.cpp
 SI5351_QUALIFICATION_TEST_SOURCE := ./WSPR-Transmitter/src/si5351_startup_quiesce_qualification_test.cpp
@@ -296,7 +299,7 @@ SIMULATED_BACKEND_TEST_SOURCE := ./WSPR-Transmitter/src/simulated_transmit_backe
 SIMULATED_BACKEND_REALTIME_TEST_SOURCE := ./WSPR-Transmitter/src/simulated_transmit_backend_realtime_test.cpp
 TRANSMISSION_CONTROLLER_CONTRACT_TEST_SOURCE := ./WSPR-Transmitter/src/transmission_controller_contract_test.cpp
 THREAD_AFFINITY_UNAVAILABLE_TEST_SOURCE := ./WSPR-Transmitter/src/thread_affinity_unavailable_test.cpp
-COMPONENT_CPP_SOURCES := $(filter-out $(PPM_MANAGER_TEST_SOURCE) $(SIGNAL_HANDLER_TEST_SOURCE) $(SINGLETON_TEST_SOURCE) $(SI5351_TEST_SOURCE) $(SI5351_PLANNER_TEST_SOURCE) $(SI5351_TRANSITION_TEST_SOURCE) $(STARTUP_QUIESCE_TEST_SOURCE) $(LEGACY_GPIO_CLOCK_MODEL_TEST_SOURCE) $(SI5351_QUALIFICATION_SOURCE) $(SI5351_QUALIFICATION_MAIN_SOURCE) $(SI5351_QUALIFICATION_TEST_SOURCE) $(RP1_GPCLK_PLANNER_TEST_SOURCE) $(RP1_GPCLK_LIFECYCLE_TEST_SOURCE) $(RP1_GPCLK_TRANSITION_TEST_SOURCE) $(RP1_GPCLK_BACKEND_TEST_SOURCE) $(RP1_GPCLK_LINUX_PROVIDER_TEST_SOURCE) $(RP1_GPCLK_DEVELOPMENT_POLICY_TEST_SOURCE) $(RP1_GPCLK_TRANSMIT_BACKEND_TEST_SOURCE) $(RP1_GPCLK_ADMIN_PROBE_SOURCE) $(SIMULATED_BACKEND_TEST_SOURCE) $(SIMULATED_BACKEND_REALTIME_TEST_SOURCE) $(TRANSMISSION_CONTROLLER_CONTRACT_TEST_SOURCE) $(THREAD_AFFINITY_UNAVAILABLE_TEST_SOURCE),$(COMPONENT_CPP_SOURCES))
+COMPONENT_CPP_SOURCES := $(filter-out $(PPM_MANAGER_TEST_SOURCE) $(SIGNAL_HANDLER_TEST_SOURCE) $(SINGLETON_TEST_SOURCE) $(SI5351_TEST_SOURCE) $(SI5351_PLANNER_TEST_SOURCE) $(SI5351_TRANSITION_TEST_SOURCE) $(STARTUP_QUIESCE_TEST_SOURCE) $(LEGACY_GPIO_CLOCK_MODEL_TEST_SOURCE) $(GPIO_FREQUENCY_CORRECTION_TEST_SOURCE) $(SI5351_QUALIFICATION_SOURCE) $(SI5351_QUALIFICATION_MAIN_SOURCE) $(SI5351_QUALIFICATION_TEST_SOURCE) $(RP1_GPCLK_PLANNER_TEST_SOURCE) $(RP1_GPCLK_LIFECYCLE_TEST_SOURCE) $(RP1_GPCLK_TRANSITION_TEST_SOURCE) $(RP1_GPCLK_BACKEND_TEST_SOURCE) $(RP1_GPCLK_LINUX_PROVIDER_TEST_SOURCE) $(RP1_GPCLK_DEVELOPMENT_POLICY_TEST_SOURCE) $(RP1_GPCLK_TRANSMIT_BACKEND_TEST_SOURCE) $(RP1_GPCLK_ADMIN_PROBE_SOURCE) $(SIMULATED_BACKEND_TEST_SOURCE) $(SIMULATED_BACKEND_REALTIME_TEST_SOURCE) $(TRANSMISSION_CONTROLLER_CONTRACT_TEST_SOURCE) $(THREAD_AFFINITY_UNAVAILABLE_TEST_SOURCE),$(COMPONENT_CPP_SOURCES))
 COMPONENT_CPP_SOURCES := $(filter-out $(TRANSMITTER_SHARED_CPP_SOURCES) $(TRANSMITTER_BACKEND_CPP_SOURCES),$(COMPONENT_CPP_SOURCES))
 
 CPP_SOURCES := $(LOCAL_CPP_SOURCES) $(COMPONENT_CPP_SOURCES) $(TRANSMITTER_SHARED_CPP_SOURCES) $(SELECTED_BACKEND_CPP_SOURCES)
@@ -1102,7 +1105,7 @@ $(BIN_DIR)/$(OUT): $(PROFILE_RELEASE_BIN) FORCE_PROFILE_BINARY
 # ─────────────────────────────────────────────────────────────────────────────
 
 .PHONY: clean debug test test-tone test-oneshot install-binary FORCE_PROFILE_BINARY
-.PHONY: semantics-test legacy-gpio-clock-model-test machine-power-control-test websocket-lifecycle-test wspr-band-catalog-test gpio-band-policy-test
+.PHONY: semantics-test legacy-gpio-clock-model-test gpio-frequency-correction-test machine-power-control-test websocket-lifecycle-test wspr-band-catalog-test gpio-band-policy-test
 .PHONY: support-request-guard-test privileged-network-policy-test backend-http-guard-test websocket-upgrade-guard-test apache-privileged-network-policy-test privileged-network-transaction-test privileged-network-runtime-test privileged-network-runtime-wiring-test privileged-network-admin-test support-bundle-job-manager-test support-bundle-result-validator-test
 .PHONY: support-bundle-collector-executor-test support-bundle-runtime-test support-bundle-runtime-installer-test
 .PHONY: installer-dependency-test ui-publication-test support-bundle-age-dependency-test support-bundle-http-test support-bundle-web-server-wiring-test
@@ -1190,7 +1193,7 @@ test-oneshot: debug
 	$(Q)echo "Running test oneshot with sudo privileges."
 	$(Q)$(SUDO) ./$(BIN_DIR)/$(TEST_OUT) -D -x 1 $(WSPR_PARAMS)
 
-semantics-test: legacy-gpio-clock-model-test $(BIN_DIR)/$(SEMANTICS_TEST_OUT) $(BIN_DIR)/$(CLEANUP_LIFECYCLE_TEST_OUT) $(BIN_DIR)/$(UI_SOURCE_REGRESSION_TEST_OUT) $(BIN_DIR)/$(GPIO_BAND_POLICY_TEST_OUT)
+semantics-test: legacy-gpio-clock-model-test gpio-frequency-correction-test $(BIN_DIR)/$(SEMANTICS_TEST_OUT) $(BIN_DIR)/$(CLEANUP_LIFECYCLE_TEST_OUT) $(BIN_DIR)/$(UI_SOURCE_REGRESSION_TEST_OUT) $(BIN_DIR)/$(GPIO_BAND_POLICY_TEST_OUT)
 	$(Q)echo "Running runtime semantics tests."
 	$(Q)./$(BIN_DIR)/$(SEMANTICS_TEST_OUT)
 	$(Q)echo "Running cleanup lifecycle tests."
@@ -1213,6 +1216,14 @@ $(BIN_DIR)/$(LEGACY_GPIO_CLOCK_MODEL_TEST_OUT): WSPR-Transmitter/src/legacy_gpio
 legacy-gpio-clock-model-test: $(BIN_DIR)/$(LEGACY_GPIO_CLOCK_MODEL_TEST_OUT)
 	$(Q)echo "Running hardware-independent legacy GPIO clock-model tests."
 	$(Q)./$(BIN_DIR)/$(LEGACY_GPIO_CLOCK_MODEL_TEST_OUT)
+
+$(BIN_DIR)/$(GPIO_FREQUENCY_CORRECTION_TEST_OUT): tests/gpio_frequency_correction_test.cpp system_clock_frequency_estimate.cpp
+	$(Q)mkdir -p $(BIN_DIR)
+	$(Q)$(CXX) $(GPIO_FREQUENCY_CORRECTION_TEST_FLAGS) $^ -o $@
+
+gpio-frequency-correction-test: $(BIN_DIR)/$(GPIO_FREQUENCY_CORRECTION_TEST_OUT)
+	$(Q)echo "Running hardware-independent GPIO frequency-correction tests."
+	$(Q)./$(BIN_DIR)/$(GPIO_FREQUENCY_CORRECTION_TEST_OUT)
 
 websocket-lifecycle-test: $(BIN_DIR)/$(WEBSOCKET_LIFECYCLE_TEST_OUT)
 	$(Q)./$(BIN_DIR)/$(WEBSOCKET_LIFECYCLE_TEST_OUT)

--- a/src/WSPR-Transmitter/src/gpio_band_policy.hpp
+++ b/src/WSPR-Transmitter/src/gpio_band_policy.hpp
@@ -73,10 +73,11 @@ inline QualificationState qualification_for(
 
     if (band == "2200m")
     {
-        if (profile == HardwareProfile::BCM2711_750_MHZ_PLLD ||
+        if (profile == HardwareProfile::BCM2711 ||
             profile == HardwareProfile::RP1_GPCLK)
             return QualificationState::QUALIFIED;
-        if (profile == HardwareProfile::LEGACY_500_MHZ_PLLD)
+        if (profile == HardwareProfile::BCM2835 ||
+            profile == HardwareProfile::BCM2836_BCM2837)
         {
             if (mode == TransmissionMode::TONE ||
                 mode == TransmissionMode::QRSS ||
@@ -93,7 +94,7 @@ inline QualificationState qualification_for(
     if (!questionable)
         return QualificationState::QUALIFIED;
 
-    if (profile == HardwareProfile::BCM2711_750_MHZ_PLLD)
+    if (profile == HardwareProfile::BCM2711)
     {
         if (band == "1.25m" || band == "70cm")
             return QualificationState::UNAVAILABLE;

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model.cpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model.cpp
@@ -16,6 +16,9 @@ namespace wsprrypi
 
         constexpr double kIssue429SdrInterceptHz = 0.4484;
         constexpr double kIssue429SdrProportionalPpm = 1.01012;
+        constexpr double kGpclkDividerScale = 4096.0;
+        constexpr double kGpclkDividerMask = 16777215.0;
+        constexpr double kGpclkMash3MinimumDivisor = 5.0;
 
         void requireFinite(double value, const char *name)
         {
@@ -82,6 +85,119 @@ namespace wsprrypi
 
         throw std::invalid_argument(
             "Unsupported legacy GPIO processor/parent clock model.");
+    }
+
+    std::optional<LegacyGpioProcessorProfile>
+    legacyGpioProcessorProfileFromRevision(std::uint32_t revision) noexcept
+    {
+        if (revision == 0U)
+            return std::nullopt;
+        if ((revision & 0x800000U) == 0U)
+            return LegacyGpioProcessorProfile::Bcm2835;
+
+        switch ((revision >> 12U) & 0xFU)
+        {
+        case 0U: return LegacyGpioProcessorProfile::Bcm2835;
+        case 1U:
+        case 2U: return LegacyGpioProcessorProfile::Bcm2836Bcm2837;
+        case 3U: return LegacyGpioProcessorProfile::Bcm2711;
+        default: return std::nullopt;
+        }
+    }
+
+    LegacyGpioCorrectionComposition composeLegacyGpioCorrection(
+        double intrinsic_ppm,
+        double additional_ppm) noexcept
+    {
+        LegacyGpioCorrectionComposition result;
+        result.intrinsic_ppm = intrinsic_ppm;
+        result.additional_ppm = additional_ppm;
+        if (!std::isfinite(intrinsic_ppm) ||
+            std::fabs(intrinsic_ppm) > kMaximumLegacyGpioCorrectionPpm ||
+            !std::isfinite(additional_ppm) ||
+            std::fabs(additional_ppm) > kMaximumLegacyGpioCorrectionPpm)
+        {
+            return result;
+        }
+        result.effective_ppm = intrinsic_ppm + additional_ppm;
+        result.valid = std::isfinite(result.effective_ppm) &&
+            std::fabs(result.effective_ppm) <=
+                kMaximumLegacyGpioCorrectionPpm;
+        return result;
+    }
+
+    bool legacyGpioClockCanRepresent(
+        double source_hz,
+        double minimum_tone_hz,
+        double maximum_tone_hz) noexcept
+    {
+        if (!std::isfinite(source_hz) || source_hz <= 0.0 ||
+            !std::isfinite(minimum_tone_hz) || minimum_tone_hz <= 0.0 ||
+            !std::isfinite(maximum_tone_hz) ||
+            maximum_tone_hz < minimum_tone_hz)
+        {
+            return false;
+        }
+        for (const double tone_hz : {minimum_tone_hz, maximum_tone_hz})
+        {
+            const double scaled = source_hz / tone_hz * kGpclkDividerScale;
+            const double lower = std::floor(scaled);
+            const double upper = lower + 1.0;
+            if (!std::isfinite(scaled) ||
+                lower < kGpclkMash3MinimumDivisor * kGpclkDividerScale ||
+                upper > kGpclkDividerMask)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    LegacyGpioClockSelection selectLegacyGpioClock(
+        LegacyGpioProcessorProfile processor,
+        double minimum_tone_hz,
+        double maximum_tone_hz,
+        double effective_ppm)
+    {
+        const auto try_parent = [&](LegacyGpioClockParent parent)
+            -> std::optional<LegacyGpioClockSelection>
+        {
+            const auto model = legacyGpioClockModel(processor, parent);
+            const double additional_ppm =
+                effective_ppm -
+                model.intrinsic_system_to_rf_difference_ppm;
+            const auto correction = composeLegacyGpioCorrection(
+                model.intrinsic_system_to_rf_difference_ppm,
+                additional_ppm);
+            if (!correction.valid)
+                throw std::invalid_argument(
+                    "Legacy GPIO correction composition is invalid.");
+            const double corrected_rate_hz =
+                model.nominal_rate_hz *
+                (1.0 + correction.effective_ppm * 1.0e-6);
+            if (legacyGpioClockCanRepresent(
+                    corrected_rate_hz,
+                    minimum_tone_hz,
+                    maximum_tone_hz))
+            {
+                return LegacyGpioClockSelection{
+                    model,
+                    correction,
+                    corrected_rate_hz};
+            }
+            return std::nullopt;
+        };
+
+        if (const auto plld = try_parent(LegacyGpioClockParent::PllD))
+            return *plld;
+        if (processor == LegacyGpioProcessorProfile::Bcm2711)
+        {
+            if (const auto oscillator =
+                    try_parent(LegacyGpioClockParent::Oscillator))
+                return *oscillator;
+        }
+        throw std::out_of_range(
+            "Legacy GPIO frequency cannot be represented by an available parent.");
     }
 
     double deriveLegacyGpioIntrinsicDifferencePpm(

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model.cpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model.cpp
@@ -12,8 +12,8 @@ namespace wsprrypi
         constexpr double kBcm2711PllDHz = 750000000.0;
         constexpr double kBcm2711OscillatorHz = 54000000.0;
         constexpr double kBcm2835IntrinsicPpm = -2.5;
-        constexpr double kBcm2711PllDIntrinsicPpm = 0.153768;
-        constexpr double kBcm2711OscillatorIntrinsicPpm = -15.035290;
+        constexpr double kBcm2711PllDIntrinsicPpm = 0.0;
+        constexpr double kBcm2711OscillatorIntrinsicPpm = 0.0;
         constexpr double kLaterLegacyPllDIntrinsicPpm = 0.0;
 
         constexpr double kIssue429SdrInterceptHz = 0.4484;
@@ -71,7 +71,7 @@ namespace wsprrypi
                     parent,
                     kBcm2711PllDHz,
                     kBcm2711PllDIntrinsicPpm,
-                    LegacyGpioIntrinsicEvidence::ConductedPromoted};
+                    LegacyGpioIntrinsicEvidence::DiscoveryBaseline};
             }
             if (parent == LegacyGpioClockParent::Oscillator)
             {
@@ -80,7 +80,7 @@ namespace wsprrypi
                     parent,
                     kBcm2711OscillatorHz,
                     kBcm2711OscillatorIntrinsicPpm,
-                    LegacyGpioIntrinsicEvidence::ConductedPromoted};
+                    LegacyGpioIntrinsicEvidence::DiscoveryBaseline};
             }
             break;
         }

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model.cpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model.cpp
@@ -13,6 +13,7 @@ namespace wsprrypi
         constexpr double kBcm2711OscillatorHz = 54000000.0;
         constexpr double kBcm2835IntrinsicPpm = -2.5;
         constexpr double kBcm2711PllDIntrinsicPpm = 0.153768;
+        constexpr double kBcm2711OscillatorIntrinsicPpm = -15.035290;
         constexpr double kDiscoveryBaselinePpm = 0.0;
 
         constexpr double kIssue429SdrInterceptHz = 0.4484;
@@ -78,8 +79,8 @@ namespace wsprrypi
                     processor,
                     parent,
                     kBcm2711OscillatorHz,
-                    kDiscoveryBaselinePpm,
-                    LegacyGpioIntrinsicEvidence::DiscoveryBaseline};
+                    kBcm2711OscillatorIntrinsicPpm,
+                    LegacyGpioIntrinsicEvidence::ConductedPromoted};
             }
             break;
         }
@@ -167,6 +168,50 @@ namespace wsprrypi
             const double additional_ppm =
                 effective_ppm -
                 model.intrinsic_system_to_rf_difference_ppm;
+            const auto correction = composeLegacyGpioCorrection(
+                model.intrinsic_system_to_rf_difference_ppm,
+                additional_ppm);
+            if (!correction.valid)
+                throw std::invalid_argument(
+                    "Legacy GPIO correction composition is invalid.");
+            const double corrected_rate_hz =
+                model.nominal_rate_hz *
+                (1.0 + correction.effective_ppm * 1.0e-6);
+            if (legacyGpioClockCanRepresent(
+                    corrected_rate_hz,
+                    minimum_tone_hz,
+                    maximum_tone_hz))
+            {
+                return LegacyGpioClockSelection{
+                    model,
+                    correction,
+                    corrected_rate_hz};
+            }
+            return std::nullopt;
+        };
+
+        if (const auto plld = try_parent(LegacyGpioClockParent::PllD))
+            return *plld;
+        if (processor == LegacyGpioProcessorProfile::Bcm2711)
+        {
+            if (const auto oscillator =
+                    try_parent(LegacyGpioClockParent::Oscillator))
+                return *oscillator;
+        }
+        throw std::out_of_range(
+            "Legacy GPIO frequency cannot be represented by an available parent.");
+    }
+
+    LegacyGpioClockSelection selectLegacyGpioClockForAdditionalCorrection(
+        LegacyGpioProcessorProfile processor,
+        double minimum_tone_hz,
+        double maximum_tone_hz,
+        double additional_ppm)
+    {
+        const auto try_parent = [&](LegacyGpioClockParent parent)
+            -> std::optional<LegacyGpioClockSelection>
+        {
+            const auto model = legacyGpioClockModel(processor, parent);
             const auto correction = composeLegacyGpioCorrection(
                 model.intrinsic_system_to_rf_difference_ppm,
                 additional_ppm);

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model.cpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model.cpp
@@ -1,0 +1,163 @@
+#include "legacy_gpio_clock_model.hpp"
+
+#include <cmath>
+#include <stdexcept>
+
+namespace wsprrypi
+{
+    namespace
+    {
+        constexpr double kBcm2835PllDHz = 500000000.0;
+        constexpr double kLaterLegacyPllDHz = 500000000.0;
+        constexpr double kBcm2711PllDHz = 750000000.0;
+        constexpr double kBcm2711OscillatorHz = 54000000.0;
+        constexpr double kBcm2835IntrinsicPpm = -2.5;
+        constexpr double kDiscoveryBaselinePpm = 0.0;
+
+        constexpr double kIssue429SdrInterceptHz = 0.4484;
+        constexpr double kIssue429SdrProportionalPpm = 1.01012;
+
+        void requireFinite(double value, const char *name)
+        {
+            if (!std::isfinite(value))
+                throw std::invalid_argument(name);
+        }
+
+        void requirePositiveFrequency(double value, const char *name)
+        {
+            if (!std::isfinite(value) || value <= 0.0)
+                throw std::invalid_argument(name);
+        }
+    }
+
+    LegacyGpioClockModel legacyGpioClockModel(
+        LegacyGpioProcessorProfile processor,
+        LegacyGpioClockParent parent)
+    {
+        switch (processor)
+        {
+        case LegacyGpioProcessorProfile::Bcm2835:
+            if (parent == LegacyGpioClockParent::PllD)
+            {
+                return {
+                    processor,
+                    parent,
+                    kBcm2835PllDHz,
+                    kBcm2835IntrinsicPpm,
+                    LegacyGpioIntrinsicEvidence::HistoricalAuthoritative};
+            }
+            break;
+        case LegacyGpioProcessorProfile::Bcm2836Bcm2837:
+            if (parent == LegacyGpioClockParent::PllD)
+            {
+                return {
+                    processor,
+                    parent,
+                    kLaterLegacyPllDHz,
+                    kDiscoveryBaselinePpm,
+                    LegacyGpioIntrinsicEvidence::DiscoveryBaseline};
+            }
+            break;
+        case LegacyGpioProcessorProfile::Bcm2711:
+            if (parent == LegacyGpioClockParent::PllD)
+            {
+                return {
+                    processor,
+                    parent,
+                    kBcm2711PllDHz,
+                    kDiscoveryBaselinePpm,
+                    LegacyGpioIntrinsicEvidence::DiscoveryBaseline};
+            }
+            if (parent == LegacyGpioClockParent::Oscillator)
+            {
+                return {
+                    processor,
+                    parent,
+                    kBcm2711OscillatorHz,
+                    kDiscoveryBaselinePpm,
+                    LegacyGpioIntrinsicEvidence::DiscoveryBaseline};
+            }
+            break;
+        }
+
+        throw std::invalid_argument(
+            "Unsupported legacy GPIO processor/parent clock model.");
+    }
+
+    double deriveLegacyGpioIntrinsicDifferencePpm(
+        double rf_parent_error_ppm,
+        double frozen_system_clock_correction_ppm)
+    {
+        requireFinite(
+            rf_parent_error_ppm,
+            "RF parent error PPM must be finite.");
+        requireFinite(
+            frozen_system_clock_correction_ppm,
+            "Frozen system-clock correction PPM must be finite.");
+
+        const double difference =
+            rf_parent_error_ppm - frozen_system_clock_correction_ppm;
+        requireFinite(
+            difference,
+            "Derived intrinsic system-to-RF difference must be finite.");
+        return difference;
+    }
+
+    double calibrateIssue429SdrFrequencyHz(double raw_detected_hz)
+    {
+        requirePositiveFrequency(
+            raw_detected_hz,
+            "Raw detected SDR frequency must be finite and positive.");
+
+        const double calibrated =
+            (raw_detected_hz - kIssue429SdrInterceptHz) /
+            (1.0 + kIssue429SdrProportionalPpm * 1.0e-6);
+        requirePositiveFrequency(
+            calibrated,
+            "Calibrated SDR frequency must be finite and positive.");
+        return calibrated;
+    }
+
+    LegacyGpioSdrMeasurement analyzeIssue429SdrMeasurement(
+        double requested_fundamental_hz,
+        double raw_detected_hz,
+        std::uint32_t authenticated_harmonic_number)
+    {
+        requirePositiveFrequency(
+            requested_fundamental_hz,
+            "Requested fundamental frequency must be finite and positive.");
+        if (authenticated_harmonic_number == 0)
+        {
+            throw std::invalid_argument(
+                "Authenticated harmonic number must be positive.");
+        }
+
+        const double calibrated_detected_hz =
+            calibrateIssue429SdrFrequencyHz(raw_detected_hz);
+        const double calibrated_fundamental_hz =
+            calibrated_detected_hz /
+            static_cast<double>(authenticated_harmonic_number);
+        requirePositiveFrequency(
+            calibrated_fundamental_hz,
+            "Calibrated fundamental frequency must be finite and positive.");
+
+        const double calibrated_rf_error_hz =
+            calibrated_fundamental_hz - requested_fundamental_hz;
+        const double calibrated_rf_error_ppm =
+            calibrated_rf_error_hz / requested_fundamental_hz * 1.0e6;
+        requireFinite(
+            calibrated_rf_error_hz,
+            "Calibrated RF error must be finite.");
+        requireFinite(
+            calibrated_rf_error_ppm,
+            "Calibrated RF error PPM must be finite.");
+
+        return {
+            raw_detected_hz,
+            calibrated_detected_hz,
+            calibrated_fundamental_hz,
+            calibrated_rf_error_hz,
+            calibrated_rf_error_ppm,
+            authenticated_harmonic_number};
+    }
+}

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model.cpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model.cpp
@@ -12,6 +12,7 @@ namespace wsprrypi
         constexpr double kBcm2711PllDHz = 750000000.0;
         constexpr double kBcm2711OscillatorHz = 54000000.0;
         constexpr double kBcm2835IntrinsicPpm = -2.5;
+        constexpr double kBcm2711PllDIntrinsicPpm = 0.153768;
         constexpr double kDiscoveryBaselinePpm = 0.0;
 
         constexpr double kIssue429SdrInterceptHz = 0.4484;
@@ -68,8 +69,8 @@ namespace wsprrypi
                     processor,
                     parent,
                     kBcm2711PllDHz,
-                    kDiscoveryBaselinePpm,
-                    LegacyGpioIntrinsicEvidence::DiscoveryBaseline};
+                    kBcm2711PllDIntrinsicPpm,
+                    LegacyGpioIntrinsicEvidence::ConductedPromoted};
             }
             if (parent == LegacyGpioClockParent::Oscillator)
             {

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model.cpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model.cpp
@@ -14,7 +14,7 @@ namespace wsprrypi
         constexpr double kBcm2835IntrinsicPpm = -2.5;
         constexpr double kBcm2711PllDIntrinsicPpm = 0.153768;
         constexpr double kBcm2711OscillatorIntrinsicPpm = -15.035290;
-        constexpr double kDiscoveryBaselinePpm = 0.0;
+        constexpr double kLaterLegacyPllDIntrinsicPpm = 0.0;
 
         constexpr double kIssue429SdrInterceptHz = 0.4484;
         constexpr double kIssue429SdrProportionalPpm = 1.01012;
@@ -59,8 +59,8 @@ namespace wsprrypi
                     processor,
                     parent,
                     kLaterLegacyPllDHz,
-                    kDiscoveryBaselinePpm,
-                    LegacyGpioIntrinsicEvidence::DiscoveryBaseline};
+                    kLaterLegacyPllDIntrinsicPpm,
+                    LegacyGpioIntrinsicEvidence::ConductedPromoted};
             }
             break;
         case LegacyGpioProcessorProfile::Bcm2711:

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model.hpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 
 namespace wsprrypi
 {
@@ -41,6 +42,42 @@ namespace wsprrypi
     LegacyGpioClockModel legacyGpioClockModel(
         LegacyGpioProcessorProfile processor,
         LegacyGpioClockParent parent);
+
+    /** Decode the processor field from a Raspberry Pi revision value. */
+    std::optional<LegacyGpioProcessorProfile>
+    legacyGpioProcessorProfileFromRevision(std::uint32_t revision) noexcept;
+
+    inline constexpr double kMaximumLegacyGpioCorrectionPpm = 200.0;
+
+    struct LegacyGpioCorrectionComposition
+    {
+        bool valid = false;
+        double intrinsic_ppm = 0.0;
+        double additional_ppm = 0.0;
+        double effective_ppm = 0.0;
+    };
+
+    LegacyGpioCorrectionComposition composeLegacyGpioCorrection(
+        double intrinsic_ppm,
+        double additional_ppm) noexcept;
+
+    struct LegacyGpioClockSelection
+    {
+        LegacyGpioClockModel model;
+        LegacyGpioCorrectionComposition correction;
+        double corrected_rate_hz = 0.0;
+    };
+
+    bool legacyGpioClockCanRepresent(
+        double source_hz,
+        double minimum_tone_hz,
+        double maximum_tone_hz) noexcept;
+
+    LegacyGpioClockSelection selectLegacyGpioClock(
+        LegacyGpioProcessorProfile processor,
+        double minimum_tone_hz,
+        double maximum_tone_hz,
+        double effective_ppm);
 
     /**
      * Derive the intrinsic system-to-RF difference D = P - S.

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model.hpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <cstdint>
+
+namespace wsprrypi
+{
+    /** Processor identities covered by the non-RP1 legacy GPIO clock model. */
+    enum class LegacyGpioProcessorProfile
+    {
+        Bcm2835,
+        Bcm2836Bcm2837,
+        Bcm2711
+    };
+
+    /** Parent identities available to the legacy GPIO GPCLK0 path. */
+    enum class LegacyGpioClockParent
+    {
+        PllD,
+        Oscillator
+    };
+
+    enum class LegacyGpioIntrinsicEvidence
+    {
+        HistoricalAuthoritative,
+        DiscoveryBaseline
+    };
+
+    struct LegacyGpioClockModel
+    {
+        LegacyGpioProcessorProfile processor;
+        LegacyGpioClockParent parent;
+        double nominal_rate_hz;
+        double intrinsic_system_to_rf_difference_ppm;
+        LegacyGpioIntrinsicEvidence intrinsic_evidence;
+    };
+
+    /**
+     * Return authoritative Phase 1 data for an exact processor/parent pair.
+     * Unsupported pairings fail closed instead of selecting a fallback.
+     */
+    LegacyGpioClockModel legacyGpioClockModel(
+        LegacyGpioProcessorProfile processor,
+        LegacyGpioClockParent parent);
+
+    /**
+     * Derive the intrinsic system-to-RF difference D = P - S.
+     * All inputs use the positive-fast source-rate convention.
+     */
+    double deriveLegacyGpioIntrinsicDifferencePpm(
+        double rf_parent_error_ppm,
+        double frozen_system_clock_correction_ppm);
+
+    struct LegacyGpioSdrMeasurement
+    {
+        double raw_detected_hz;
+        double calibrated_detected_hz;
+        double calibrated_fundamental_hz;
+        double calibrated_rf_error_hz;
+        double calibrated_rf_error_ppm;
+        std::uint32_t harmonic_number;
+    };
+
+    /** Apply the Issue 429 wspr5 affine calibration inverse exactly once. */
+    double calibrateIssue429SdrFrequencyHz(double raw_detected_hz);
+
+    /**
+     * Analyze an authenticated fundamental or harmonic observation.
+     * SDR calibration is applied to the raw detected frequency before any
+     * harmonic division. This campaign-only calculation is not a production
+     * frequency correction or configuration input.
+     */
+    LegacyGpioSdrMeasurement analyzeIssue429SdrMeasurement(
+        double requested_fundamental_hz,
+        double raw_detected_hz,
+        std::uint32_t authenticated_harmonic_number);
+}

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model.hpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model.hpp
@@ -23,7 +23,8 @@ namespace wsprrypi
     enum class LegacyGpioIntrinsicEvidence
     {
         HistoricalAuthoritative,
-        DiscoveryBaseline
+        DiscoveryBaseline,
+        ConductedPromoted
     };
 
     struct LegacyGpioClockModel

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model.hpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model.hpp
@@ -81,6 +81,16 @@ namespace wsprrypi
         double effective_ppm);
 
     /**
+     * Select a parent while composing that parent's intrinsic with one
+     * additional correction.
+     */
+    LegacyGpioClockSelection selectLegacyGpioClockForAdditionalCorrection(
+        LegacyGpioProcessorProfile processor,
+        double minimum_tone_hz,
+        double maximum_tone_hz,
+        double additional_ppm);
+
+    /**
      * Derive the intrinsic system-to-RF difference D = P - S.
      * All inputs use the positive-fast source-rate convention.
      */

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model_test.cpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model_test.cpp
@@ -1,0 +1,283 @@
+#include "legacy_gpio_clock_model.hpp"
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace
+{
+    int failures = 0;
+
+    void expect(bool condition, const std::string& message)
+    {
+        if (!condition)
+        {
+            std::cerr << "FAIL: " << message << '\n';
+            ++failures;
+        }
+    }
+
+    bool nearlyEqual(double actual, double expected, double tolerance)
+    {
+        return std::fabs(actual - expected) <= tolerance;
+    }
+
+    template <typename Callback>
+    void expectInvalid(Callback callback, const std::string& message)
+    {
+        bool rejected = false;
+        try
+        {
+            callback();
+        }
+        catch (const std::invalid_argument&)
+        {
+            rejected = true;
+        }
+        expect(rejected, message);
+    }
+
+    void testExactClockModels()
+    {
+        using namespace wsprrypi;
+
+        const auto bcm2835 = legacyGpioClockModel(
+            LegacyGpioProcessorProfile::Bcm2835,
+            LegacyGpioClockParent::PllD);
+        expect(
+            bcm2835.processor == LegacyGpioProcessorProfile::Bcm2835 &&
+                bcm2835.parent == LegacyGpioClockParent::PllD &&
+                bcm2835.nominal_rate_hz == 500000000.0 &&
+                bcm2835.intrinsic_system_to_rf_difference_ppm == -2.5 &&
+                bcm2835.intrinsic_evidence ==
+                    LegacyGpioIntrinsicEvidence::HistoricalAuthoritative,
+            "BCM2835 PLLD must preserve the authoritative 500 MHz, -2.5 PPM model");
+
+        const auto later500 = legacyGpioClockModel(
+            LegacyGpioProcessorProfile::Bcm2836Bcm2837,
+            LegacyGpioClockParent::PllD);
+        expect(
+            later500.processor ==
+                    LegacyGpioProcessorProfile::Bcm2836Bcm2837 &&
+                later500.parent == LegacyGpioClockParent::PllD &&
+                later500.nominal_rate_hz == 500000000.0 &&
+                later500.intrinsic_system_to_rf_difference_ppm == 0.0 &&
+                later500.intrinsic_evidence ==
+                    LegacyGpioIntrinsicEvidence::DiscoveryBaseline,
+            "BCM2836/BCM2837 PLLD must exclude the BCM2835 intrinsic constant");
+
+        const auto bcm2711PllD = legacyGpioClockModel(
+            LegacyGpioProcessorProfile::Bcm2711,
+            LegacyGpioClockParent::PllD);
+        const auto bcm2711Oscillator = legacyGpioClockModel(
+            LegacyGpioProcessorProfile::Bcm2711,
+            LegacyGpioClockParent::Oscillator);
+        expect(
+            bcm2711PllD.processor == LegacyGpioProcessorProfile::Bcm2711 &&
+                bcm2711PllD.parent == LegacyGpioClockParent::PllD &&
+                bcm2711PllD.nominal_rate_hz == 750000000.0 &&
+                bcm2711PllD.intrinsic_system_to_rf_difference_ppm == 0.0,
+            "BCM2711 PLLD must use its independent 750 MHz discovery baseline");
+        expect(
+            bcm2711Oscillator.processor ==
+                    LegacyGpioProcessorProfile::Bcm2711 &&
+                bcm2711Oscillator.parent ==
+                    LegacyGpioClockParent::Oscillator &&
+                bcm2711Oscillator.nominal_rate_hz == 54000000.0 &&
+                bcm2711Oscillator.intrinsic_system_to_rf_difference_ppm == 0.0,
+            "BCM2711 oscillator must use its independent 54 MHz discovery baseline");
+
+        expectInvalid(
+            [] {
+                (void)legacyGpioClockModel(
+                    LegacyGpioProcessorProfile::Bcm2835,
+                    LegacyGpioClockParent::Oscillator);
+            },
+            "BCM2835 oscillator pairing must fail closed");
+        expectInvalid(
+            [] {
+                (void)legacyGpioClockModel(
+                    LegacyGpioProcessorProfile::Bcm2836Bcm2837,
+                    LegacyGpioClockParent::Oscillator);
+            },
+            "BCM2836/BCM2837 oscillator pairing must fail closed");
+        expectInvalid(
+            [] {
+                (void)legacyGpioClockModel(
+                    static_cast<LegacyGpioProcessorProfile>(-1),
+                    LegacyGpioClockParent::PllD);
+            },
+            "unknown processor identity must fail closed");
+        expectInvalid(
+            [] {
+                (void)legacyGpioClockModel(
+                    LegacyGpioProcessorProfile::Bcm2711,
+                    static_cast<LegacyGpioClockParent>(-1));
+            },
+            "unknown parent identity must fail closed");
+    }
+
+    void testIntrinsicDifferenceSignAndValidation()
+    {
+        using namespace wsprrypi;
+
+        expect(
+            deriveLegacyGpioIntrinsicDifferencePpm(4.25, 1.5) == 2.75,
+            "D = P - S must preserve the positive-fast sign convention");
+        expect(
+            deriveLegacyGpioIntrinsicDifferencePpm(-4.25, -1.5) == -2.75,
+            "negative-fast inputs must preserve D = P - S without inversion");
+
+        for (const double invalid : {
+                 std::numeric_limits<double>::infinity(),
+                 -std::numeric_limits<double>::infinity(),
+                 std::numeric_limits<double>::quiet_NaN()})
+        {
+            expectInvalid(
+                [invalid] {
+                    (void)deriveLegacyGpioIntrinsicDifferencePpm(invalid, 0.0);
+                },
+                "non-finite P must fail closed");
+            expectInvalid(
+                [invalid] {
+                    (void)deriveLegacyGpioIntrinsicDifferencePpm(0.0, invalid);
+                },
+                "non-finite S must fail closed");
+        }
+    }
+
+    double rawDetectedForReference(double reference_hz)
+    {
+        return reference_hz + 0.4484 + reference_hz * 1.01012e-6;
+    }
+
+    void testExactSdrInverseAndRfError()
+    {
+        using namespace wsprrypi;
+
+        constexpr double reference_hz = 10000000.0;
+        const double raw_hz = rawDetectedForReference(reference_hz);
+        const double calibrated_hz =
+            calibrateIssue429SdrFrequencyHz(raw_hz);
+        expect(
+            nearlyEqual(
+                calibrated_hz,
+                reference_hz,
+                5.0e-9),
+            "exact SDR inverse must recover a synthetic reference frequency");
+        expect(
+            std::fabs(raw_hz - reference_hz) > 10.0,
+            "omitting the SDR inverse must remain detectable in the fixture");
+        expect(
+            std::fabs(
+                calibrateIssue429SdrFrequencyHz(calibrated_hz) -
+                reference_hz) > 10.0,
+            "applying the SDR inverse twice must remain detectable in the fixture");
+
+        constexpr double requested_hz = 14097100.0;
+        constexpr double physical_error_ppm = 3.25;
+        const double actual_hz = requested_hz * (1.0 + physical_error_ppm * 1.0e-6);
+        const auto measurement = analyzeIssue429SdrMeasurement(
+            requested_hz,
+            rawDetectedForReference(actual_hz),
+            1);
+        expect(
+            nearlyEqual(measurement.calibrated_fundamental_hz, actual_hz, 1.0e-8) &&
+                nearlyEqual(
+                    measurement.calibrated_rf_error_hz,
+                    actual_hz - requested_hz,
+                    1.0e-8) &&
+                nearlyEqual(
+                    measurement.calibrated_rf_error_ppm,
+                    physical_error_ppm,
+                    1.0e-9),
+            "measurement analysis must retain calibrated hertz and positive-fast PPM error");
+
+        constexpr double negative_error_ppm = -4.5;
+        const double slow_actual_hz =
+            requested_hz * (1.0 + negative_error_ppm * 1.0e-6);
+        const auto slow_measurement = analyzeIssue429SdrMeasurement(
+            requested_hz,
+            rawDetectedForReference(slow_actual_hz),
+            1);
+        expect(
+            nearlyEqual(
+                slow_measurement.calibrated_rf_error_ppm,
+                negative_error_ppm,
+                1.0e-9),
+            "measurement analysis must preserve negative-fast RF error");
+    }
+
+    void testHarmonicCalibrationOrdering()
+    {
+        using namespace wsprrypi;
+
+        constexpr double requested_hz = 1000000.0;
+        constexpr std::uint32_t harmonic = 7;
+        constexpr double actual_fundamental_hz = requested_hz + 0.125;
+        const double actual_harmonic_hz = actual_fundamental_hz * harmonic;
+        const double raw_harmonic_hz = rawDetectedForReference(actual_harmonic_hz);
+        const auto measurement = analyzeIssue429SdrMeasurement(
+            requested_hz,
+            raw_harmonic_hz,
+            harmonic);
+
+        const double wrong_order =
+            calibrateIssue429SdrFrequencyHz(raw_harmonic_hz / harmonic);
+        expect(
+            nearlyEqual(
+                measurement.calibrated_fundamental_hz,
+                actual_fundamental_hz,
+                1.0e-9),
+            "harmonic analysis must calibrate the raw harmonic before division");
+        expect(
+            std::fabs(wrong_order - actual_fundamental_hz) > 0.1,
+            "the fixture must detect division before removal of the affine intercept");
+    }
+
+    void testMeasurementValidation()
+    {
+        using namespace wsprrypi;
+
+        for (const double invalid : {
+                 0.0,
+                 -1.0,
+                 std::numeric_limits<double>::infinity(),
+                 std::numeric_limits<double>::quiet_NaN()})
+        {
+            expectInvalid(
+                [invalid] { (void)calibrateIssue429SdrFrequencyHz(invalid); },
+                "invalid raw detected frequency must fail closed");
+            expectInvalid(
+                [invalid] {
+                    (void)analyzeIssue429SdrMeasurement(invalid, 1000000.0, 1);
+                },
+                "invalid requested fundamental must fail closed");
+        }
+        expectInvalid(
+            [] {
+                (void)analyzeIssue429SdrMeasurement(1000000.0, 1000000.0, 0);
+            },
+            "zero unauthenticated harmonic number must fail closed");
+    }
+}
+
+int main()
+{
+    testExactClockModels();
+    testIntrinsicDifferenceSignAndValidation();
+    testExactSdrInverseAndRfError();
+    testHarmonicCalibrationOrdering();
+    testMeasurementValidation();
+
+    if (failures != 0)
+    {
+        std::cerr << failures << " legacy GPIO clock-model test(s) failed\n";
+        return EXIT_FAILURE;
+    }
+    std::cout << "Legacy GPIO clock-model tests passed\n";
+    return EXIT_SUCCESS;
+}

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model_test.cpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model_test.cpp
@@ -80,8 +80,10 @@ namespace
             bcm2711PllD.processor == LegacyGpioProcessorProfile::Bcm2711 &&
                 bcm2711PllD.parent == LegacyGpioClockParent::PllD &&
                 bcm2711PllD.nominal_rate_hz == 750000000.0 &&
-                bcm2711PllD.intrinsic_system_to_rf_difference_ppm == 0.0,
-            "BCM2711 PLLD must use its independent 750 MHz discovery baseline");
+                bcm2711PllD.intrinsic_system_to_rf_difference_ppm == 0.153768 &&
+                bcm2711PllD.intrinsic_evidence ==
+                    LegacyGpioIntrinsicEvidence::ConductedPromoted,
+            "BCM2711 PLLD must use its promoted conducted 750 MHz intrinsic value");
         expect(
             bcm2711Oscillator.processor ==
                     LegacyGpioProcessorProfile::Bcm2711 &&

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model_test.cpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model_test.cpp
@@ -67,8 +67,8 @@ namespace
                 later500.nominal_rate_hz == 500000000.0 &&
                 later500.intrinsic_system_to_rf_difference_ppm == 0.0 &&
                 later500.intrinsic_evidence ==
-                    LegacyGpioIntrinsicEvidence::DiscoveryBaseline,
-            "BCM2836/BCM2837 PLLD must exclude the BCM2835 intrinsic constant");
+                    LegacyGpioIntrinsicEvidence::ConductedPromoted,
+            "BCM2836/BCM2837/BCM2837B0 PLLD must use the promoted conducted 500 MHz zero intrinsic residual");
 
         const auto bcm2711PllD = legacyGpioClockModel(
             LegacyGpioProcessorProfile::Bcm2711,

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model_test.cpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model_test.cpp
@@ -90,8 +90,25 @@ namespace
                 bcm2711Oscillator.parent ==
                     LegacyGpioClockParent::Oscillator &&
                 bcm2711Oscillator.nominal_rate_hz == 54000000.0 &&
-                bcm2711Oscillator.intrinsic_system_to_rf_difference_ppm == 0.0,
-            "BCM2711 oscillator must use its independent 54 MHz discovery baseline");
+                bcm2711Oscillator.intrinsic_system_to_rf_difference_ppm ==
+                    -15.035290 &&
+                bcm2711Oscillator.intrinsic_evidence ==
+                    LegacyGpioIntrinsicEvidence::ConductedPromoted,
+            "BCM2711 oscillator must use its promoted conducted 54 MHz intrinsic value");
+
+        const auto selectedOscillator =
+            selectLegacyGpioClockForAdditionalCorrection(
+                LegacyGpioProcessorProfile::Bcm2711,
+                137500.0,
+                137502.0,
+                9.616);
+        expect(
+            selectedOscillator.model.parent ==
+                    LegacyGpioClockParent::Oscillator &&
+                selectedOscillator.correction.intrinsic_ppm == -15.035290 &&
+                selectedOscillator.correction.additional_ppm == 9.616 &&
+                selectedOscillator.correction.effective_ppm == -5.419290,
+            "parent-aware composition must apply the oscillator intrinsic exactly once");
 
         expectInvalid(
             [] {

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model_test.cpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model_test.cpp
@@ -80,10 +80,10 @@ namespace
             bcm2711PllD.processor == LegacyGpioProcessorProfile::Bcm2711 &&
                 bcm2711PllD.parent == LegacyGpioClockParent::PllD &&
                 bcm2711PllD.nominal_rate_hz == 750000000.0 &&
-                bcm2711PllD.intrinsic_system_to_rf_difference_ppm == 0.153768 &&
+                bcm2711PllD.intrinsic_system_to_rf_difference_ppm == 0.0 &&
                 bcm2711PllD.intrinsic_evidence ==
-                    LegacyGpioIntrinsicEvidence::ConductedPromoted,
-            "BCM2711 PLLD must use its promoted conducted 750 MHz intrinsic value");
+                    LegacyGpioIntrinsicEvidence::DiscoveryBaseline,
+            "BCM2711 PLLD must use the conservative 750 MHz zero baseline pending GPS-referenced qualification");
         expect(
             bcm2711Oscillator.processor ==
                     LegacyGpioProcessorProfile::Bcm2711 &&
@@ -91,10 +91,10 @@ namespace
                     LegacyGpioClockParent::Oscillator &&
                 bcm2711Oscillator.nominal_rate_hz == 54000000.0 &&
                 bcm2711Oscillator.intrinsic_system_to_rf_difference_ppm ==
-                    -15.035290 &&
+                    0.0 &&
                 bcm2711Oscillator.intrinsic_evidence ==
-                    LegacyGpioIntrinsicEvidence::ConductedPromoted,
-            "BCM2711 oscillator must use its promoted conducted 54 MHz intrinsic value");
+                    LegacyGpioIntrinsicEvidence::DiscoveryBaseline,
+            "BCM2711 oscillator must use the conservative 54 MHz zero baseline pending GPS-referenced qualification");
 
         const auto selectedOscillator =
             selectLegacyGpioClockForAdditionalCorrection(
@@ -105,9 +105,9 @@ namespace
         expect(
             selectedOscillator.model.parent ==
                     LegacyGpioClockParent::Oscillator &&
-                selectedOscillator.correction.intrinsic_ppm == -15.035290 &&
+                selectedOscillator.correction.intrinsic_ppm == 0.0 &&
                 selectedOscillator.correction.additional_ppm == 9.616 &&
-                selectedOscillator.correction.effective_ppm == -5.419290,
+                selectedOscillator.correction.effective_ppm == 9.616,
             "parent-aware composition must apply the oscillator intrinsic exactly once");
 
         expectInvalid(

--- a/src/WSPR-Transmitter/src/legacy_gpio_clock_model_test.cpp
+++ b/src/WSPR-Transmitter/src/legacy_gpio_clock_model_test.cpp
@@ -1,4 +1,5 @@
 #include "legacy_gpio_clock_model.hpp"
+#include "transmission_request.hpp"
 
 #include <cmath>
 #include <cstdlib>
@@ -149,6 +150,117 @@ namespace
         }
     }
 
+    void testRevisionIdentityResolution()
+    {
+        using namespace wsprrypi;
+
+        expect(
+            !legacyGpioProcessorProfileFromRevision(0U).has_value(),
+            "missing revision identity must fail closed");
+        expect(
+            legacyGpioProcessorProfileFromRevision(0x0002U) ==
+                LegacyGpioProcessorProfile::Bcm2835,
+            "old-style nonzero revisions must retain BCM2835 identity");
+        expect(
+            legacyGpioProcessorProfileFromRevision(0x800000U) ==
+                LegacyGpioProcessorProfile::Bcm2835,
+            "new-style processor code 0 must resolve BCM2835");
+        expect(
+            legacyGpioProcessorProfileFromRevision(0x801000U) ==
+                LegacyGpioProcessorProfile::Bcm2836Bcm2837 &&
+                legacyGpioProcessorProfileFromRevision(0x802000U) ==
+                    LegacyGpioProcessorProfile::Bcm2836Bcm2837,
+            "new-style processor codes 1 and 2 must resolve the later 500 MHz class");
+        expect(
+            legacyGpioProcessorProfileFromRevision(0x803000U) ==
+                LegacyGpioProcessorProfile::Bcm2711,
+            "new-style processor code 3 must resolve BCM2711");
+        expect(
+            !legacyGpioProcessorProfileFromRevision(0x804000U).has_value() &&
+                !legacyGpioProcessorProfileFromRevision(0x80F000U).has_value(),
+            "unknown new-style processor codes must fail closed");
+        expect(
+            legacyHardwareProfile(
+                LegacyGpioProcessorProfile::Bcm2835) ==
+                    HardwareProfile::BCM2835 &&
+                legacyHardwareProfile(
+                    LegacyGpioProcessorProfile::Bcm2836Bcm2837) ==
+                    HardwareProfile::BCM2836_BCM2837 &&
+                legacyHardwareProfile(
+                    LegacyGpioProcessorProfile::Bcm2711) ==
+                    HardwareProfile::BCM2711,
+            "exact processor identities must map to exact committed profiles");
+        expect(
+            legacyHardwareProfileMatches(
+                HardwareProfile::BCM2711,
+                LegacyGpioProcessorProfile::Bcm2711) &&
+                !legacyHardwareProfileMatches(
+                    HardwareProfile::BCM2835,
+                    LegacyGpioProcessorProfile::Bcm2711) &&
+                !legacyHardwareProfileMatches(
+                    HardwareProfile::UNSPECIFIED,
+                    LegacyGpioProcessorProfile::Bcm2835),
+            "profile agreement must reject wrong and unspecified identities");
+    }
+
+    void testParentSelectionAndCorrectionBoundaries()
+    {
+        using namespace wsprrypi;
+
+        const auto bcm2835 = selectLegacyGpioClock(
+            LegacyGpioProcessorProfile::Bcm2835,
+            14097100.0,
+            14097100.0,
+            -1.5);
+        expect(
+            bcm2835.model.parent == LegacyGpioClockParent::PllD &&
+                bcm2835.correction.intrinsic_ppm == -2.5 &&
+                bcm2835.correction.additional_ppm == 1.0 &&
+                bcm2835.correction.effective_ppm == -1.5 &&
+                nearlyEqual(
+                    bcm2835.corrected_rate_hz,
+                    500000000.0 * (1.0 - 1.5e-6),
+                    1.0e-6),
+            "BCM2835 selection must apply its intrinsic correction exactly once");
+
+        const auto later = selectLegacyGpioClock(
+            LegacyGpioProcessorProfile::Bcm2836Bcm2837,
+            14097100.0,
+            14097100.0,
+            1.0);
+        expect(
+            later.correction.intrinsic_ppm == 0.0 &&
+                later.correction.additional_ppm == 1.0 &&
+                later.correction.effective_ppm == 1.0,
+            "later 500 MHz profiles must never inherit the BCM2835 intrinsic value");
+
+        constexpr double maximum_divisor = 16777215.0 / 4096.0;
+        for (const double effective_ppm : {-100.0, 0.0, 100.0})
+        {
+            const double corrected_plld_hz =
+                750000000.0 * (1.0 + effective_ppm * 1.0e-6);
+            const double transition_hz = corrected_plld_hz / maximum_divisor;
+            const auto below = selectLegacyGpioClock(
+                LegacyGpioProcessorProfile::Bcm2711,
+                transition_hz - 100.0,
+                transition_hz - 100.0,
+                effective_ppm);
+            const auto above = selectLegacyGpioClock(
+                LegacyGpioProcessorProfile::Bcm2711,
+                transition_hz + 100.0,
+                transition_hz + 100.0,
+                effective_ppm);
+            expect(
+                below.model.parent == LegacyGpioClockParent::Oscillator &&
+                    above.model.parent == LegacyGpioClockParent::PllD,
+                "BCM2711 parent transition must track zero and signed corrections");
+            expect(
+                below.model.nominal_rate_hz == 54000000.0 &&
+                    above.model.nominal_rate_hz == 750000000.0,
+                "BCM2711 parents must retain independent nominal rates across transitions");
+        }
+    }
+
     double rawDetectedForReference(double reference_hz)
     {
         return reference_hz + 0.4484 + reference_hz * 1.01012e-6;
@@ -269,6 +381,8 @@ int main()
 {
     testExactClockModels();
     testIntrinsicDifferenceSignAndValidation();
+    testRevisionIdentityResolution();
+    testParentSelectionAndCorrectionBoundaries();
     testExactSdrInverseAndRfError();
     testHarmonicCalibrationOrdering();
     testMeasurementValidation();

--- a/src/WSPR-Transmitter/src/rp1_gpclk_planner.hpp
+++ b/src/WSPR-Transmitter/src/rp1_gpclk_planner.hpp
@@ -9,6 +9,9 @@
 namespace wsprrypi
 {
 
+/** Conservative RP1 GPCLK intrinsic baseline pending conducted qualification. */
+inline constexpr double kRp1GpclkIntrinsicSourceRatePpm = 0.0;
+
 struct Rp1GpclkPlannerInput
 {
     double center_frequency_hz{0.0};

--- a/src/WSPR-Transmitter/src/rp1_gpclk_planner_test.cpp
+++ b/src/WSPR-Transmitter/src/rp1_gpclk_planner_test.cpp
@@ -260,6 +260,9 @@ void test_integer_boundary_and_invalid_inputs()
 
 int main()
 {
+    expect(wsprrypi::kRp1GpclkIntrinsicSourceRatePpm == 0.0,
+        "RP1 GPCLK must retain the conservative zero intrinsic baseline");
+
     test_all_bands_and_parents();
     test_single_word_evidence();
     test_calibration_direction_and_determinism();

--- a/src/WSPR-Transmitter/src/startup_quiesce_test.cpp
+++ b/src/WSPR-Transmitter/src/startup_quiesce_test.cpp
@@ -715,7 +715,7 @@ namespace
 
         const auto pi4_2200m_range = tone_range(137500.0);
         const auto pi4_2200m = gpioPlanRfClock(
-            GpioProcessorClockProfile::Bcm2711,
+            wsprrypi::LegacyGpioProcessorProfile::Bcm2711,
             pi4_2200m_range.first,
             pi4_2200m_range.second,
             0.0);
@@ -726,7 +726,7 @@ namespace
 
         const auto pi4_630m_range = tone_range(475700.0);
         const auto pi4_630m = gpioPlanRfClock(
-            GpioProcessorClockProfile::Bcm2711,
+            wsprrypi::LegacyGpioProcessorProfile::Bcm2711,
             pi4_630m_range.first,
             pi4_630m_range.second,
             0.0);
@@ -735,7 +735,7 @@ namespace
                "Pi 4 630 m must retain the preferred 750 MHz PLLD source");
 
         const auto legacy_2200m = gpioPlanRfClock(
-            GpioProcessorClockProfile::Legacy500Mhz,
+            wsprrypi::LegacyGpioProcessorProfile::Bcm2836Bcm2837,
             pi4_2200m_range.first,
             pi4_2200m_range.second,
             0.0);
@@ -743,15 +743,47 @@ namespace
                    legacy_2200m.nominal_hz == 500e6,
                "500 MHz processors must retain PLLD for representable 2200 m output");
 
+        const auto bcm2835 = gpioPlanRfClock(
+            wsprrypi::LegacyGpioProcessorProfile::Bcm2835,
+            14097100.0,
+            14097100.0,
+            -1.5);
+        expect(
+            bcm2835.parent == wsprrypi::LegacyGpioClockParent::PllD &&
+                bcm2835.nominal_hz == 500e6 &&
+                bcm2835.intrinsic_ppm == -2.5 &&
+                bcm2835.additional_ppm == 1.0 &&
+                bcm2835.effective_ppm == -1.5 &&
+                bcm2835.corrected_hz == 500e6 * (1.0 - 1.5e-6),
+            "BCM2835 planning must apply its intrinsic correction exactly once");
+
+        expect(
+            gpioHardwareProfileMatchesProcessor(
+                wsprrypi::HardwareProfile::BCM2835,
+                wsprrypi::LegacyGpioProcessorProfile::Bcm2835) &&
+                gpioHardwareProfileMatchesProcessor(
+                    wsprrypi::HardwareProfile::BCM2836_BCM2837,
+                    wsprrypi::LegacyGpioProcessorProfile::Bcm2836Bcm2837) &&
+                gpioHardwareProfileMatchesProcessor(
+                    wsprrypi::HardwareProfile::BCM2711,
+                    wsprrypi::LegacyGpioProcessorProfile::Bcm2711) &&
+                !gpioHardwareProfileMatchesProcessor(
+                    wsprrypi::HardwareProfile::BCM2835,
+                    wsprrypi::LegacyGpioProcessorProfile::Bcm2711) &&
+                !gpioHardwareProfileMatchesProcessor(
+                    wsprrypi::HardwareProfile::UNSPECIFIED,
+                    wsprrypi::LegacyGpioProcessorProfile::Bcm2835),
+            "backend profile agreement must accept exact identity and reject contradictions");
+
         constexpr double pi4_plld_boundary_hz =
             750e6 / (static_cast<double>(0x00FFFFFFu) / 4096.0);
         const auto below_boundary = gpioPlanRfClock(
-            GpioProcessorClockProfile::Bcm2711,
+            wsprrypi::LegacyGpioProcessorProfile::Bcm2711,
             pi4_plld_boundary_hz - 100.0,
             pi4_plld_boundary_hz - 100.0,
             0.0);
         const auto above_boundary = gpioPlanRfClock(
-            GpioProcessorClockProfile::Bcm2711,
+            wsprrypi::LegacyGpioProcessorProfile::Bcm2711,
             pi4_plld_boundary_hz + 100.0,
             pi4_plld_boundary_hz + 100.0,
             0.0);
@@ -760,7 +792,7 @@ namespace
                "Pi 4 source selection must switch safely across the PLLD divisor boundary");
 
         const auto ppm_plan = gpioPlanRfClock(
-            GpioProcessorClockProfile::Bcm2711,
+            wsprrypi::LegacyGpioProcessorProfile::Bcm2711,
             pi4_2200m_range.first,
             pi4_2200m_range.second,
             100.0);

--- a/src/WSPR-Transmitter/src/transmission_request.hpp
+++ b/src/WSPR-Transmitter/src/transmission_request.hpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "transmission_payloads.hpp"
+#include "legacy_gpio_clock_model.hpp"
 
 namespace wsprrypi
 {
@@ -30,11 +31,34 @@ enum class ClockSource
 enum class HardwareProfile
 {
     UNSPECIFIED,
-    LEGACY_500_MHZ_PLLD,
-    BCM2711_750_MHZ_PLLD,
+    BCM2835,
+    BCM2836_BCM2837,
+    BCM2711,
     RP1_GPCLK,
     SI5351
 };
+
+inline HardwareProfile legacyHardwareProfile(
+    LegacyGpioProcessorProfile processor) noexcept
+{
+    switch (processor)
+    {
+    case LegacyGpioProcessorProfile::Bcm2835:
+        return HardwareProfile::BCM2835;
+    case LegacyGpioProcessorProfile::Bcm2836Bcm2837:
+        return HardwareProfile::BCM2836_BCM2837;
+    case LegacyGpioProcessorProfile::Bcm2711:
+        return HardwareProfile::BCM2711;
+    }
+    return HardwareProfile::UNSPECIFIED;
+}
+
+inline bool legacyHardwareProfileMatches(
+    HardwareProfile committed_profile,
+    LegacyGpioProcessorProfile detected_processor) noexcept
+{
+    return committed_profile == legacyHardwareProfile(detected_processor);
+}
 
 struct RequestId
 {

--- a/src/WSPR-Transmitter/src/wspr_transmit_backend_rpi.cpp
+++ b/src/WSPR-Transmitter/src/wspr_transmit_backend_rpi.cpp
@@ -486,79 +486,50 @@ namespace
 {
     constexpr std::uint32_t kGpclkDividerMask = 0x00FFFFFFu;
     constexpr double kGpclkDividerScale = 4096.0;
-    constexpr double kGpclkMash3MinimumDivisor = 5.0;
 
     bool gpioClockCanRepresent(
         double source_hz,
         double minimum_tone_hz,
         double maximum_tone_hz)
     {
-        if (!std::isfinite(source_hz) || source_hz <= 0.0 ||
-            !std::isfinite(minimum_tone_hz) || minimum_tone_hz <= 0.0 ||
-            !std::isfinite(maximum_tone_hz) ||
-            maximum_tone_hz < minimum_tone_hz)
-        {
-            return false;
-        }
-
-        for (const double tone_hz : {minimum_tone_hz, maximum_tone_hz})
-        {
-            const double scaled = source_hz / tone_hz * kGpclkDividerScale;
-            const double lower = std::floor(scaled);
-            const double upper = lower + 1.0;
-            if (!std::isfinite(scaled) ||
-                lower < kGpclkMash3MinimumDivisor * kGpclkDividerScale ||
-                upper > static_cast<double>(kGpclkDividerMask))
-            {
-                return false;
-            }
-        }
-        return true;
+        return wsprrypi::legacyGpioClockCanRepresent(
+            source_hz,
+            minimum_tone_hz,
+            maximum_tone_hz);
     }
 }
 
 GpioRfClockPlan gpioPlanRfClock(
-    GpioProcessorClockProfile profile,
+    wsprrypi::LegacyGpioProcessorProfile profile,
     double minimum_tone_hz,
     double maximum_tone_hz,
     double source_rate_ppm)
 {
-    const double plld_nominal_hz =
-        profile == GpioProcessorClockProfile::Bcm2711 ? 750e6 : 500e6;
-    const double corrected_plld_hz =
-        gpioCorrectedPlldFrequency(plld_nominal_hz, source_rate_ppm);
-    if (gpioClockCanRepresent(
-            corrected_plld_hz,
-            minimum_tone_hz,
-            maximum_tone_hz))
-    {
-        return {
-            GpioRfClockSource::PllD,
-            plld_nominal_hz,
-            corrected_plld_hz};
-    }
+    const auto selected = wsprrypi::selectLegacyGpioClock(
+        profile,
+        minimum_tone_hz,
+        maximum_tone_hz,
+        source_rate_ppm);
+    return {
+        profile,
+        selected.model.parent,
+        selected.model.parent == wsprrypi::LegacyGpioClockParent::Oscillator
+            ? GpioRfClockSource::Oscillator
+            : GpioRfClockSource::PllD,
+        selected.model.nominal_rate_hz,
+        selected.correction.intrinsic_ppm,
+        selected.correction.additional_ppm,
+        selected.correction.effective_ppm,
+        selected.corrected_rate_hz};
+}
 
-    if (profile == GpioProcessorClockProfile::Bcm2711)
-    {
-        constexpr double oscillator_nominal_hz = 54e6;
-        const double corrected_oscillator_hz =
-            gpioCorrectedPlldFrequency(
-                oscillator_nominal_hz,
-                source_rate_ppm);
-        if (gpioClockCanRepresent(
-                corrected_oscillator_hz,
-                minimum_tone_hz,
-                maximum_tone_hz))
-        {
-            return {
-                GpioRfClockSource::Oscillator,
-                oscillator_nominal_hz,
-                corrected_oscillator_hz};
-        }
-    }
-
-    throw std::out_of_range(
-        "GPIO RF frequency cannot be represented by an available GPCLK source.");
+bool gpioHardwareProfileMatchesProcessor(
+    wsprrypi::HardwareProfile committed_profile,
+    wsprrypi::LegacyGpioProcessorProfile detected_processor) noexcept
+{
+    return wsprrypi::legacyHardwareProfileMatches(
+        committed_profile,
+        detected_processor);
 }
 
 std::uint32_t gpioBuildDividerWord(
@@ -603,11 +574,11 @@ std::int64_t gpioDitherLowerClockCount(
 }
 
 WsprRpiBackend::DMAConfig::DMAConfig()
-    : plld_nominal_freq(500000000.0 * (1 - 2.500e-6)),
+    : plld_nominal_freq(500000000.0),
       plld_clock_frequency(plld_nominal_freq),
       gpclk_nominal_freq(plld_nominal_freq),
       gpclk_clock_frequency(gpclk_nominal_freq),
-      processor_profile(GpioProcessorClockProfile::Legacy500Mhz),
+      processor_profile(wsprrypi::LegacyGpioProcessorProfile::Bcm2836Bcm2837),
       gpclk_source(GpioRfClockSource::PllD),
       peripheral_base_virtual(nullptr),
       orig_gp0ctl(0),
@@ -699,6 +670,15 @@ wsprrypi::BackendCompileResult WsprRpiBackend::configure(
 
     if (!platform_supports_gpio_clock_transmission(&result.error))
     {
+        return result;
+    }
+
+    if (!gpioHardwareProfileMatchesProcessor(
+            plan.policy.hardware_profile,
+            dma_config_.processor_profile))
+    {
+        result.error =
+            "Committed GPIO processor profile does not match detected hardware.";
         return result;
     }
 
@@ -2134,47 +2114,23 @@ void WsprRpiBackend::get_plld()
             }
         }
         if (!cached_revision)
-        {
-            cached_revision = 0;
-        }
+            throw std::runtime_error(
+                "Unable to resolve Raspberry Pi revision for GPIO clock planning.");
     }
 
     unsigned rev = *cached_revision;
-    BCMChip proc_id;
-
-    if (rev & 0x800000)
-    {
-        auto raw = (rev & 0xF000) >> 12;
-        proc_id = static_cast<BCMChip>(raw);
-    }
-    else
-    {
-        proc_id = BCMChip::BCM_HOST_PROCESSOR_BCM2835;
-    }
-
-    double base_freq_hz = 500e6;
-    switch (proc_id)
-    {
-    case BCMChip::BCM_HOST_PROCESSOR_BCM2835:
-    case BCMChip::BCM_HOST_PROCESSOR_BCM2836:
-    case BCMChip::BCM_HOST_PROCESSOR_BCM2837:
-        base_freq_hz = 500e6;
-        dma_config_.processor_profile =
-            GpioProcessorClockProfile::Legacy500Mhz;
-        break;
-
-    case BCMChip::BCM_HOST_PROCESSOR_BCM2711:
-        base_freq_hz = 750e6;
-        dma_config_.processor_profile =
-            GpioProcessorClockProfile::Bcm2711;
-        break;
-
-    default:
+    const auto resolved_processor =
+        wsprrypi::legacyGpioProcessorProfileFromRevision(rev);
+    if (!resolved_processor.has_value())
         throw std::runtime_error(
-            std::string("Error: Unknown chipset (") +
-            std::string(to_string(proc_id)) + ")");
-    }
+            "Unsupported Raspberry Pi revision processor for GPIO clock planning.");
+    const auto processor_profile = *resolved_processor;
 
+    const auto plld_model = wsprrypi::legacyGpioClockModel(
+        processor_profile,
+        wsprrypi::LegacyGpioClockParent::PllD);
+    const double base_freq_hz = plld_model.nominal_rate_hz;
+    dma_config_.processor_profile = processor_profile;
     dma_config_.plld_nominal_freq = base_freq_hz;
     dma_config_.plld_clock_frequency = base_freq_hz;
     dma_config_.gpclk_nominal_freq = base_freq_hz;
@@ -2182,22 +2138,7 @@ void WsprRpiBackend::get_plld()
     dma_config_.gpclk_source = GpioRfClockSource::PllD;
 
     if (dma_config_.plld_clock_frequency <= 0)
-    {
-        std::ostringstream oss;
-        oss << "Error: Invalid PLLD frequency; defaulting to 500 MHz";
-        owner_.backendFireTransmitCallback(
-            WsprTransmissionCallbackEvent::LOGGING,
-            WsprTransmitLogLevel::ERROR,
-            oss.str(),
-            0.0);
-        dma_config_.plld_nominal_freq = 500e6;
-        dma_config_.plld_clock_frequency = 500e6;
-        dma_config_.gpclk_nominal_freq = 500e6;
-        dma_config_.gpclk_clock_frequency = 500e6;
-        dma_config_.processor_profile =
-            GpioProcessorClockProfile::Legacy500Mhz;
-        dma_config_.gpclk_source = GpioRfClockSource::PllD;
-    }
+        throw std::runtime_error("Resolved GPIO PLLD frequency is invalid.");
 }
 
 void WsprRpiBackend::allocate_memory_pool(unsigned numpages)
@@ -2929,10 +2870,6 @@ WsprTransmissionConfigureResult WsprRpiBackend::setup_dma_freq_table(
 
     configure_transmit_gpio(plan.tx_gpio);
 
-    dma_config_.plld_clock_frequency = gpioCorrectedPlldFrequency(
-        dma_config_.plld_nominal_freq,
-        plan.ppm);
-
     const double minimum_tone_hz =
         plan.frequency_hz - 1.5 * plan.tone_spacing_hz;
     const double maximum_tone_hz =
@@ -2942,6 +2879,19 @@ WsprTransmissionConfigureResult WsprRpiBackend::setup_dma_freq_table(
         minimum_tone_hz,
         maximum_tone_hz,
         plan.ppm);
+    const auto plld_model = wsprrypi::legacyGpioClockModel(
+        dma_config_.processor_profile,
+        wsprrypi::LegacyGpioClockParent::PllD);
+    const double plld_additional_ppm =
+        plan.ppm - plld_model.intrinsic_system_to_rf_difference_ppm;
+    const auto plld_composition = wsprrypi::composeLegacyGpioCorrection(
+        plld_model.intrinsic_system_to_rf_difference_ppm,
+        plld_additional_ppm);
+    if (!plld_composition.valid)
+        throw std::runtime_error("GPIO PLLD correction composition is invalid.");
+    dma_config_.plld_clock_frequency = gpioCorrectedPlldFrequency(
+        dma_config_.plld_nominal_freq,
+        plld_composition.effective_ppm);
     dma_config_.gpclk_nominal_freq = rf_clock.nominal_hz;
     dma_config_.gpclk_clock_frequency = rf_clock.corrected_hz;
     dma_config_.gpclk_source = rf_clock.source;
@@ -2954,6 +2904,10 @@ WsprTransmissionConfigureResult WsprRpiBackend::setup_dma_freq_table(
                     : "PLLD")
             << " nominal_hz=" << std::fixed << std::setprecision(0)
             << rf_clock.nominal_hz
+            << " intrinsic_ppm=" << std::fixed << std::setprecision(6)
+            << rf_clock.intrinsic_ppm
+            << " additional_ppm=" << rf_clock.additional_ppm
+            << " effective_ppm=" << rf_clock.effective_ppm
             << " corrected_hz=" << std::fixed << std::setprecision(3)
             << rf_clock.corrected_hz;
         owner_.backendFireTransmitCallback(

--- a/src/WSPR-Transmitter/src/wspr_transmit_backend_rpi.hpp
+++ b/src/WSPR-Transmitter/src/wspr_transmit_backend_rpi.hpp
@@ -40,6 +40,7 @@
 #include <vector>
 
 #include "transmission_backend.hpp"
+#include "legacy_gpio_clock_model.hpp"
 #include "wspr_transmit_backend.hpp"
 #include "wspr_transmit.hpp"
 
@@ -116,12 +117,6 @@ makeProductionRpiStartupQuiesceAccess();
  */
 double gpioCorrectedPlldFrequency(double nominal_hz, double source_rate_ppm);
 
-enum class GpioProcessorClockProfile
-{
-    Legacy500Mhz,
-    Bcm2711
-};
-
 enum class GpioRfClockSource : std::uint32_t
 {
     Oscillator = 1,
@@ -130,16 +125,27 @@ enum class GpioRfClockSource : std::uint32_t
 
 struct GpioRfClockPlan
 {
+    wsprrypi::LegacyGpioProcessorProfile processor{
+        wsprrypi::LegacyGpioProcessorProfile::Bcm2836Bcm2837};
+    wsprrypi::LegacyGpioClockParent parent{
+        wsprrypi::LegacyGpioClockParent::PllD};
     GpioRfClockSource source{GpioRfClockSource::PllD};
     double nominal_hz{0.0};
+    double intrinsic_ppm{0.0};
+    double additional_ppm{0.0};
+    double effective_ppm{0.0};
     double corrected_hz{0.0};
 };
 
 GpioRfClockPlan gpioPlanRfClock(
-    GpioProcessorClockProfile profile,
+    wsprrypi::LegacyGpioProcessorProfile profile,
     double minimum_tone_hz,
     double maximum_tone_hz,
     double source_rate_ppm);
+
+bool gpioHardwareProfileMatchesProcessor(
+    wsprrypi::HardwareProfile committed_profile,
+    wsprrypi::LegacyGpioProcessorProfile detected_processor) noexcept;
 
 std::uint32_t gpioBuildDividerWord(
     double source_hz,
@@ -334,7 +340,7 @@ private:
         double plld_clock_frequency;
         double gpclk_nominal_freq;
         double gpclk_clock_frequency;
-        GpioProcessorClockProfile processor_profile;
+        wsprrypi::LegacyGpioProcessorProfile processor_profile;
         GpioRfClockSource gpclk_source;
         volatile uint8_t *peripheral_base_virtual;
         uint32_t orig_gp0ctl;

--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -37,6 +37,7 @@
 #include "privileged_network_runtime.hpp"
 #include "scheduling.hpp"
 #include "signal_handler.hpp"
+#include "system_clock_frequency_estimate.hpp"
 #include "band_lookup.hpp"
 #include "wspr_transmit.hpp"
 #include "version.hpp"
@@ -4082,15 +4083,15 @@ bool parse_command_line(int argc, char *argv[])
                 {
                     print_usage("GPIO manual PPM must be a finite number.", EXIT_FAILURE);
                 }
-                double clamped_ppm = std::clamp(ppm, -200.0, 200.0);
-
-                if (ppm != clamped_ppm)
+                if (ppm < -kMaximumGpioFrequencyCorrectionPpm ||
+                    ppm > kMaximumGpioFrequencyCorrectionPpm)
                 {
-                    llog.logE(ERROR, "PPM value is outside bounds (-200 to 200), applying clamped value: ", clamped_ppm);
+                    print_usage(
+                        "GPIO manual PPM must be within -200 to 200.",
+                        EXIT_FAILURE);
                 }
 
-                // Apply the clamped value
-                config.gpio_manual_ppm = clamped_ppm;
+                config.gpio_manual_ppm = ppm;
                 config.gpio_use_system_clock_frequency_estimate = false;
                 resolve_backend_specific_config(config);
             }

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -132,6 +132,36 @@ namespace
     FrequencyEstimateQualifier frequency_estimate_qualifier;
     SystemClockFrequencyEstimate current_frequency_estimate{};
     GpioFrequencyCorrection current_gpio_correction{};
+    WsprRuntimeStatusSnapshot::GpioCorrectionProvenance
+        current_gpio_candidate_provenance{};
+    WsprRuntimeStatusSnapshot::GpioCorrectionProvenance
+        committed_gpio_correction_provenance{};
+    std::uint64_t committed_gpio_execution_sequence = 0;
+
+    const char *legacy_processor_name(
+        wsprrypi::LegacyGpioProcessorProfile profile) noexcept
+    {
+        switch (profile)
+        {
+        case wsprrypi::LegacyGpioProcessorProfile::Bcm2835: return "BCM2835";
+        case wsprrypi::LegacyGpioProcessorProfile::Bcm2836Bcm2837:
+            return "BCM2836/BCM2837";
+        case wsprrypi::LegacyGpioProcessorProfile::Bcm2711: return "BCM2711";
+        }
+        return "unavailable";
+    }
+
+    std::string utc_timestamp(std::chrono::system_clock::time_point value)
+    {
+        if (value.time_since_epoch().count() == 0)
+            return {};
+        const std::time_t raw = std::chrono::system_clock::to_time_t(value);
+        std::tm utc{};
+        gmtime_r(&raw, &utc);
+        std::ostringstream out;
+        out << std::put_time(&utc, "%Y-%m-%dT%H:%M:%SZ");
+        return out.str();
+    }
 
     std::optional<wsprrypi::LegacyGpioProcessorProfile>
     resolve_legacy_gpio_processor_profile() noexcept
@@ -161,6 +191,12 @@ namespace
         sample.leap_normal = provider.leap_normal;
         sample.source_provenance = provider.source_provenance;
         sample.source_signature = provider.source_signature;
+        if (std::isfinite(provider.age_seconds) && provider.age_seconds >= 0.0)
+        {
+            sample.snapshot_time = std::chrono::system_clock::now() -
+                std::chrono::duration_cast<std::chrono::system_clock::duration>(
+                    std::chrono::duration<double>(provider.age_seconds));
+        }
         sample.retained_source_samples = provider.retained_source_samples;
         sample.source_stability_span_seconds = provider.source_stability_span_seconds;
         sample.reason = provider.error_reason;
@@ -214,6 +250,27 @@ namespace
             selected.additional_ppm = selected.effective_ppm;
         }
         current_gpio_correction = selected;
+        current_gpio_candidate_provenance = {};
+        if (selected.valid && cfg.transmit_backend == TransmitBackendKind::GPIO)
+        {
+            const auto processor = resolve_legacy_gpio_processor_profile();
+            if (processor.has_value())
+            {
+                auto &candidate = current_gpio_candidate_provenance;
+                candidate.available = true;
+                candidate.processor_profile = legacy_processor_name(*processor);
+                candidate.selected_parent = "pending execution plan";
+                candidate.intrinsic_ppm = selected.intrinsic_ppm;
+                candidate.selected_component_ppm =
+                    selected.estimate_ppm.value_or(selected.additional_ppm);
+                candidate.conducted_residual_ppm = selected.residual_ppm;
+                candidate.final_ppm = selected.effective_ppm;
+                candidate.correction_mode = to_string(selected.mode);
+                candidate.provider_name = selected.provider_name;
+                candidate.provider_source_signature = selected.source_signature;
+                candidate.provider_snapshot_time = utc_timestamp(selected.snapshot_time);
+            }
+        }
         return current_gpio_correction;
     }
 
@@ -1199,6 +1256,68 @@ static wsprrypi::TransmissionRequest build_controller_request_from_legacy(
     return controller_request;
 }
 
+static void freeze_gpio_correction_provenance(
+    const TransmissionRequest &request,
+    std::optional<std::pair<double, double>> exact_frequency_range = std::nullopt)
+{
+    committed_gpio_correction_provenance = {};
+    if (config.transmit_backend != TransmitBackendKind::GPIO ||
+        request.isSkipWindow() || request.actual_rf_frequency_hz <= 0.0)
+    {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(frequency_estimate_mutex);
+    if (!current_gpio_candidate_provenance.available ||
+        !current_gpio_correction.valid)
+    {
+        return;
+    }
+    const auto processor = resolve_legacy_gpio_processor_profile();
+    if (!processor.has_value() ||
+        !wsprrypi::legacyHardwareProfileMatches(
+            request.hardware_profile, *processor))
+    {
+        return;
+    }
+
+    double minimum_hz = exact_frequency_range.has_value()
+        ? exact_frequency_range->first
+        : request.actual_rf_frequency_hz;
+    double maximum_hz = exact_frequency_range.has_value()
+        ? exact_frequency_range->second
+        : request.actual_rf_frequency_hz;
+    if (!exact_frequency_range.has_value() && !request.payload.empty())
+        maximum_hz += 1.5 * (12000.0 / 8192.0);
+    if (!exact_frequency_range.has_value() && request.applied_offset_hz != 0.0)
+    {
+        minimum_hz = std::min(minimum_hz,
+            request.actual_rf_frequency_hz + request.applied_offset_hz);
+        maximum_hz = std::max(maximum_hz,
+            request.actual_rf_frequency_hz + request.applied_offset_hz);
+    }
+
+    const auto selection = wsprrypi::selectLegacyGpioClock(
+        *processor, minimum_hz, maximum_hz, request.ppm);
+    auto frozen = current_gpio_candidate_provenance;
+    frozen.active = false;
+    frozen.selected_parent =
+        selection.model.parent == wsprrypi::LegacyGpioClockParent::PllD
+            ? "PLLD"
+            : "oscillator";
+    frozen.nominal_rate_hz = selection.model.nominal_rate_hz;
+    frozen.intrinsic_ppm = selection.correction.intrinsic_ppm;
+    frozen.selected_component_ppm =
+        current_gpio_correction.estimate_ppm.value_or(
+            selection.correction.additional_ppm);
+    frozen.final_ppm = selection.correction.effective_ppm;
+    frozen.execution_identity =
+        "gpio-execution-" + std::to_string(++committed_gpio_execution_sequence);
+    committed_gpio_correction_provenance = frozen;
+    current_gpio_candidate_provenance.selected_parent = frozen.selected_parent;
+    current_gpio_candidate_provenance.nominal_rate_hz = frozen.nominal_rate_hz;
+}
+
 /**
  * @brief Commit the single execution request consumed by the transmitter.
  *
@@ -1212,6 +1331,7 @@ static void commit_execution_request(
     const TransmissionRequest &request)
 {
     current_transmission_request = request;
+    freeze_gpio_correction_provenance(current_transmission_request);
     current_controller_request_for_test_storage.reset();
     committed_execution_route_for_test_storage =
         CommittedExecutionRouteForTest::NONE;
@@ -1328,6 +1448,34 @@ static void commit_execution_request(
     const TransmissionRequest &legacy_request)
 {
     current_transmission_request = legacy_request;
+    current_transmission_request.hardware_profile =
+        controller_request.policy.hardware_profile;
+    std::pair<double, double> exact_range{
+        current_transmission_request.actual_rf_frequency_hz,
+        current_transmission_request.actual_rf_frequency_hz};
+    switch (controller_request.mode)
+    {
+    case wsprrypi::TransmissionMode::FSKCW:
+    {
+        const auto &payload = std::get<wsprrypi::FskcwPayload>(
+            controller_request.payload);
+        exact_range = std::minmax(
+            payload.mark_frequency_hz, payload.space_frequency_hz);
+        break;
+    }
+    case wsprrypi::TransmissionMode::DFCW:
+    {
+        const auto &payload = std::get<wsprrypi::DfcwPayload>(
+            controller_request.payload);
+        exact_range = std::minmax(
+            payload.dot_frequency_hz, payload.dash_frequency_hz);
+        break;
+    }
+    default:
+        break;
+    }
+    freeze_gpio_correction_provenance(
+        current_transmission_request, exact_range);
     current_controller_request_for_test_storage = controller_request;
     if (suppress_scheduler_execution_for_test)
     {
@@ -1351,6 +1499,7 @@ static void clear_committed_execution_request() noexcept
     current_controller_request_for_test_storage.reset();
     committed_execution_route_for_test_storage =
         CommittedExecutionRouteForTest::NONE;
+    committed_gpio_correction_provenance = {};
 }
 
 static bool resolve_qrss_runtime_request(
@@ -5056,6 +5205,27 @@ void send_ws_message(
         j["gpio_frequency_residual_ppm"] = snapshot.gpio_frequency_residual_ppm;
         j["effective_gpio_ppm"] = snapshot.effective_gpio_ppm;
         j["frequency_estimate_age_seconds"] = snapshot.frequency_estimate_age_seconds;
+        const auto provenance_json = [](const auto &value)
+        {
+            return nlohmann::json{
+                {"available", value.available}, {"active", value.active},
+                {"processor_profile", value.processor_profile},
+                {"selected_parent", value.selected_parent},
+                {"nominal_rate_hz", value.nominal_rate_hz},
+                {"intrinsic_ppm", value.intrinsic_ppm},
+                {"selected_component_ppm", value.selected_component_ppm},
+                {"conducted_residual_ppm", value.conducted_residual_ppm},
+                {"final_ppm", value.final_ppm},
+                {"correction_mode", value.correction_mode},
+                {"provider_name", value.provider_name},
+                {"provider_source_signature", value.provider_source_signature},
+                {"provider_snapshot_time", value.provider_snapshot_time},
+                {"execution_identity", value.execution_identity}};
+        };
+        j["gpio_correction_candidate"] =
+            provenance_json(snapshot.gpio_correction_candidate);
+        j["gpio_correction_committed"] =
+            provenance_json(snapshot.gpio_correction_committed);
     }
 
     if (!message.empty())
@@ -5212,9 +5382,19 @@ WsprRuntimeStatusSnapshot current_tx_runtime_status_snapshot()
         snapshot.gpio_frequency_residual_ppm = current_gpio_correction.residual_ppm;
         snapshot.effective_gpio_ppm = current_gpio_correction.effective_ppm;
         snapshot.frequency_estimate_age_seconds = current_gpio_correction.estimate_age_seconds;
+        snapshot.gpio_correction_candidate = current_gpio_candidate_provenance;
+        snapshot.gpio_correction_committed = committed_gpio_correction_provenance;
     }
     snapshot.tx_state = wsprTransmitter.stateToStringLower(
         wsprTransmitter.getState());
+    snapshot.gpio_correction_committed.active =
+        snapshot.gpio_correction_committed.available &&
+        snapshot.tx_state == "transmitting";
+    if (current_transmission_request.actual_rf_frequency_hz <= 0.0 ||
+        current_transmission_request.isSkipWindow())
+    {
+        snapshot.gpio_correction_committed = {};
+    }
     const auto runtime_status = wsprTransmitter.runtimeExecutionStatusSnapshot();
     if (snapshot.tx_state == "transmitting")
     {

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -4150,6 +4150,10 @@ TestToneStartResult start_test_tone(const TestToneRequest &tone_request)
     {
         const GpioFrequencyCorrection selected_correction =
             select_and_publish_gpio_correction(config);
+        if (!selected_correction.valid)
+        {
+            throw std::runtime_error(selected_correction.reason);
+        }
         committed_ppm = selected_correction.effective_ppm;
         config.ppm = committed_ppm;
     }
@@ -5506,6 +5510,38 @@ bool set_config(bool force)
             }
             const GpioFrequencyCorrection selected_correction =
                 select_and_publish_gpio_correction(working_config);
+            if (!selected_correction.valid)
+            {
+                const std::string correction_error =
+                    selected_correction.reason.empty()
+                        ? "GPIO frequency correction is invalid."
+                        : selected_correction.reason;
+                llog.logS(ERROR, correction_error);
+                if (working_config.use_ini)
+                {
+                    send_ws_message(
+                        "configuration",
+                        "reload_failed",
+                        correction_error);
+                    set_managed_reload_tx_inhibited(true, correction_error);
+                    if (wsprTransmitter.getState() !=
+                        WsprTransmitter::State::TRANSMITTING)
+                    {
+                        wsprTransmitter.stopAndJoin();
+                        deassert_transmit_gpio_outputs(
+                            &config,
+                            false,
+                            "invalid GPIO frequency correction");
+                        release_idle_selector_gpio_reservations();
+                        current_transmission_request = TransmissionRequest{};
+                    }
+                }
+                if (!finalize_reload_pending())
+                {
+                    continue;
+                }
+                return working_config.use_ini;
+            }
             committed_ppm = selected_correction.effective_ppm;
             working_config.ppm = committed_ppm;
             if (ppm_update_pending)

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -133,6 +133,19 @@ namespace
     SystemClockFrequencyEstimate current_frequency_estimate{};
     GpioFrequencyCorrection current_gpio_correction{};
 
+    std::optional<wsprrypi::LegacyGpioProcessorProfile>
+    resolve_legacy_gpio_processor_profile() noexcept
+    {
+        const int generation = get_raspberry_pi_generation();
+        if (generation == 1)
+            return wsprrypi::LegacyGpioProcessorProfile::Bcm2835;
+        if (generation == 2 || generation == 3)
+            return wsprrypi::LegacyGpioProcessorProfile::Bcm2836Bcm2837;
+        if (generation == 4)
+            return wsprrypi::LegacyGpioProcessorProfile::Bcm2711;
+        return std::nullopt;
+    }
+
     SystemClockFrequencyEstimate qualify_provider_snapshot(
         const PPMProviderSnapshot &provider)
     {
@@ -158,11 +171,49 @@ namespace
         const ArgParserConfig &cfg)
     {
         std::lock_guard<std::mutex> lock(frequency_estimate_mutex);
-        current_gpio_correction = select_gpio_frequency_correction(
+        GpioFrequencyCorrection selected = select_gpio_frequency_correction(
             cfg.use_system_clock_frequency_estimate,
             cfg.gpio_frequency_residual_ppm,
             cfg.gpio_manual_ppm,
             current_frequency_estimate);
+        if (selected.valid && cfg.transmit_backend == TransmitBackendKind::GPIO)
+        {
+            const auto processor = resolve_legacy_gpio_processor_profile();
+
+            if (!processor.has_value())
+            {
+                selected.valid = false;
+                selected.reason =
+                    "Unable to resolve an exact legacy GPIO processor profile.";
+            }
+            else
+            {
+                const auto model = wsprrypi::legacyGpioClockModel(
+                    *processor,
+                    wsprrypi::LegacyGpioClockParent::PllD);
+                const double additional_ppm = selected.effective_ppm;
+                const auto composition = wsprrypi::composeLegacyGpioCorrection(
+                    model.intrinsic_system_to_rf_difference_ppm,
+                    additional_ppm);
+                if (!composition.valid)
+                {
+                    selected.valid = false;
+                    selected.reason =
+                        "Intrinsic plus additional GPIO correction is outside +/-200 PPM.";
+                }
+                else
+                {
+                    selected.intrinsic_ppm = composition.intrinsic_ppm;
+                    selected.additional_ppm = composition.additional_ppm;
+                    selected.effective_ppm = composition.effective_ppm;
+                }
+            }
+        }
+        else if (selected.valid)
+        {
+            selected.additional_ppm = selected.effective_ppm;
+        }
+        current_gpio_correction = selected;
         return current_gpio_correction;
     }
 
@@ -1266,10 +1317,10 @@ static wsprrypi::HardwareProfile to_controller_profile(
         return wsprrypi::HardwareProfile::UNSPECIFIED;
     if (backend == TransmitBackendKind::RP1_GPCLK)
         return wsprrypi::HardwareProfile::RP1_GPCLK;
-    const int generation = get_raspberry_pi_generation();
-    if (generation == 4)
-        return wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD;
-    return wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD;
+    const auto processor = resolve_legacy_gpio_processor_profile();
+    if (processor.has_value())
+        return wsprrypi::legacyHardwareProfile(*processor);
+    return wsprrypi::HardwareProfile::UNSPECIFIED;
 }
 
 static void commit_execution_request(

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -42,6 +42,7 @@
 #include "scheduling.hpp"
 #include "rp1_gpclk_route_service.hpp"
 #include "WSPR-Transmitter/src/rp1_gpclk_development_policy.hpp"
+#include "WSPR-Transmitter/src/rp1_gpclk_planner.hpp"
 #include "test_tone_frequency_plan.hpp"
 #include "test_tone_selector_plan.hpp"
 
@@ -212,37 +213,41 @@ namespace
             cfg.gpio_frequency_residual_ppm,
             cfg.gpio_manual_ppm,
             current_frequency_estimate);
-        if (selected.valid && cfg.transmit_backend == TransmitBackendKind::GPIO)
+        if (selected.valid && transmit_backend_uses_gpio_output(
+                cfg.transmit_backend))
         {
-            const auto processor = resolve_legacy_gpio_processor_profile();
-
-            if (!processor.has_value())
+            double intrinsic_ppm =
+                wsprrypi::kRp1GpclkIntrinsicSourceRatePpm;
+            if (cfg.transmit_backend == TransmitBackendKind::GPIO)
             {
-                selected.valid = false;
-                selected.reason =
-                    "Unable to resolve an exact legacy GPIO processor profile.";
-            }
-            else
-            {
-                const auto model = wsprrypi::legacyGpioClockModel(
-                    *processor,
-                    wsprrypi::LegacyGpioClockParent::PllD);
-                const double additional_ppm = selected.effective_ppm;
-                const auto composition = wsprrypi::composeLegacyGpioCorrection(
-                    model.intrinsic_system_to_rf_difference_ppm,
-                    additional_ppm);
-                if (!composition.valid)
+                const auto processor = resolve_legacy_gpio_processor_profile();
+                if (!processor.has_value())
                 {
                     selected.valid = false;
                     selected.reason =
-                        "Intrinsic plus additional GPIO correction is outside +/-200 PPM.";
+                        "Unable to resolve an exact legacy GPIO processor profile.";
+                    current_gpio_correction = selected;
+                    current_gpio_candidate_provenance = {};
+                    return current_gpio_correction;
                 }
-                else
-                {
-                    selected.intrinsic_ppm = composition.intrinsic_ppm;
-                    selected.additional_ppm = composition.additional_ppm;
-                    selected.effective_ppm = composition.effective_ppm;
-                }
+                const auto model = wsprrypi::legacyGpioClockModel(
+                    *processor,
+                    wsprrypi::LegacyGpioClockParent::PllD);
+                intrinsic_ppm = model.intrinsic_system_to_rf_difference_ppm;
+            }
+            const auto composition = wsprrypi::composeLegacyGpioCorrection(
+                intrinsic_ppm, selected.effective_ppm);
+            if (!composition.valid)
+            {
+                selected.valid = false;
+                selected.reason =
+                    "Intrinsic plus additional GPIO correction is outside +/-200 PPM.";
+            }
+            else
+            {
+                selected.intrinsic_ppm = composition.intrinsic_ppm;
+                selected.additional_ppm = composition.additional_ppm;
+                selected.effective_ppm = composition.effective_ppm;
             }
         }
         else if (selected.valid)
@@ -251,24 +256,32 @@ namespace
         }
         current_gpio_correction = selected;
         current_gpio_candidate_provenance = {};
-        if (selected.valid && cfg.transmit_backend == TransmitBackendKind::GPIO)
+        if (selected.valid && transmit_backend_uses_gpio_output(
+                cfg.transmit_backend))
         {
-            const auto processor = resolve_legacy_gpio_processor_profile();
-            if (processor.has_value())
+            auto &candidate = current_gpio_candidate_provenance;
+            candidate.available = true;
+            candidate.intrinsic_ppm = selected.intrinsic_ppm;
+            candidate.selected_component_ppm =
+                selected.estimate_ppm.value_or(selected.additional_ppm);
+            candidate.conducted_residual_ppm = selected.residual_ppm;
+            candidate.final_ppm = selected.effective_ppm;
+            candidate.correction_mode = to_string(selected.mode);
+            candidate.provider_name = selected.provider_name;
+            candidate.provider_source_signature = selected.source_signature;
+            candidate.provider_snapshot_time = utc_timestamp(selected.snapshot_time);
+            if (cfg.transmit_backend == TransmitBackendKind::RP1_GPCLK)
             {
-                auto &candidate = current_gpio_candidate_provenance;
-                candidate.available = true;
+                candidate.processor_profile = "RP1";
+                candidate.selected_parent = "PLL_SYS";
+                candidate.nominal_rate_hz =
+                    wsprrypi::kRp1GpclkDevelopmentNominalParentFrequencyHz;
+            }
+            else
+            {
+                const auto processor = resolve_legacy_gpio_processor_profile();
                 candidate.processor_profile = legacy_processor_name(*processor);
                 candidate.selected_parent = "pending execution plan";
-                candidate.intrinsic_ppm = selected.intrinsic_ppm;
-                candidate.selected_component_ppm =
-                    selected.estimate_ppm.value_or(selected.additional_ppm);
-                candidate.conducted_residual_ppm = selected.residual_ppm;
-                candidate.final_ppm = selected.effective_ppm;
-                candidate.correction_mode = to_string(selected.mode);
-                candidate.provider_name = selected.provider_name;
-                candidate.provider_source_signature = selected.source_signature;
-                candidate.provider_snapshot_time = utc_timestamp(selected.snapshot_time);
             }
         }
         return current_gpio_correction;
@@ -1261,7 +1274,7 @@ static void freeze_gpio_correction_provenance(
     std::optional<std::pair<double, double>> exact_frequency_range = std::nullopt)
 {
     committed_gpio_correction_provenance = {};
-    if (config.transmit_backend != TransmitBackendKind::GPIO ||
+    if (!transmit_backend_uses_gpio_output(config.transmit_backend) ||
         request.isSkipWindow() || request.actual_rf_frequency_hz <= 0.0)
     {
         return;
@@ -1273,13 +1286,28 @@ static void freeze_gpio_correction_provenance(
     {
         return;
     }
+    if (config.transmit_backend == TransmitBackendKind::RP1_GPCLK)
+    {
+        if (request.hardware_profile != wsprrypi::HardwareProfile::RP1_GPCLK)
+            return;
+
+        request.ppm = current_gpio_correction.effective_ppm;
+        auto frozen = current_gpio_candidate_provenance;
+        frozen.active = false;
+        frozen.final_ppm = current_gpio_correction.effective_ppm;
+        frozen.execution_identity =
+            "gpio-execution-" +
+            std::to_string(++committed_gpio_execution_sequence);
+        committed_gpio_correction_provenance = frozen;
+        current_gpio_candidate_provenance.final_ppm = frozen.final_ppm;
+        return;
+    }
+
     const auto processor = resolve_legacy_gpio_processor_profile();
     if (!processor.has_value() ||
         !wsprrypi::legacyHardwareProfileMatches(
             request.hardware_profile, *processor))
-    {
         return;
-    }
 
     double minimum_hz = exact_frequency_range.has_value()
         ? exact_frequency_range->first

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -1257,7 +1257,7 @@ static wsprrypi::TransmissionRequest build_controller_request_from_legacy(
 }
 
 static void freeze_gpio_correction_provenance(
-    const TransmissionRequest &request,
+    TransmissionRequest &request,
     std::optional<std::pair<double, double>> exact_frequency_range = std::nullopt)
 {
     committed_gpio_correction_provenance = {};
@@ -1297,8 +1297,17 @@ static void freeze_gpio_correction_provenance(
             request.actual_rf_frequency_hz + request.applied_offset_hz);
     }
 
-    const auto selection = wsprrypi::selectLegacyGpioClock(
-        *processor, minimum_hz, maximum_hz, request.ppm);
+    const auto selection =
+        wsprrypi::selectLegacyGpioClockForAdditionalCorrection(
+            *processor,
+            minimum_hz,
+            maximum_hz,
+            current_gpio_correction.additional_ppm);
+    request.ppm = selection.correction.effective_ppm;
+    current_gpio_correction.intrinsic_ppm =
+        selection.correction.intrinsic_ppm;
+    current_gpio_correction.effective_ppm =
+        selection.correction.effective_ppm;
     auto frozen = current_gpio_candidate_provenance;
     frozen.active = false;
     frozen.selected_parent =
@@ -1316,6 +1325,8 @@ static void freeze_gpio_correction_provenance(
     committed_gpio_correction_provenance = frozen;
     current_gpio_candidate_provenance.selected_parent = frozen.selected_parent;
     current_gpio_candidate_provenance.nominal_rate_hz = frozen.nominal_rate_hz;
+    current_gpio_candidate_provenance.intrinsic_ppm = frozen.intrinsic_ppm;
+    current_gpio_candidate_provenance.final_ppm = frozen.final_ppm;
 }
 
 /**

--- a/src/scheduling.hpp
+++ b/src/scheduling.hpp
@@ -352,6 +352,25 @@ struct WsprRuntimeStatusSnapshot
     double gpio_frequency_residual_ppm = 0.0;
     double effective_gpio_ppm = 0.0;
     double frequency_estimate_age_seconds = 0.0;
+    struct GpioCorrectionProvenance
+    {
+        bool available = false;
+        bool active = false;
+        std::string processor_profile;
+        std::string selected_parent;
+        double nominal_rate_hz = 0.0;
+        double intrinsic_ppm = 0.0;
+        double selected_component_ppm = 0.0;
+        double conducted_residual_ppm = 0.0;
+        double final_ppm = 0.0;
+        std::string correction_mode;
+        std::string provider_name;
+        std::string provider_source_signature;
+        std::string provider_snapshot_time;
+        std::string execution_identity;
+    };
+    GpioCorrectionProvenance gpio_correction_candidate;
+    GpioCorrectionProvenance gpio_correction_committed;
     std::string rp1_package_expected;
     std::string rp1_route_requested;
     std::string rp1_route_persisted;

--- a/src/system_clock_frequency_estimate.cpp
+++ b/src/system_clock_frequency_estimate.cpp
@@ -34,6 +34,10 @@ SystemClockFrequencyEstimate FrequencyEstimateQualifier::evaluate(
         {
             sample.last_qualified_frequency_ppm = last_qualified_->frequency_ppm;
             sample.last_qualified_age_seconds = age;
+            sample.provider_name = last_qualified_->provider_name;
+            sample.source_provenance = last_qualified_->source_provenance;
+            sample.source_signature = last_qualified_->source_signature;
+            sample.snapshot_time = last_qualified_->snapshot_time;
         }
     };
     sample.qualification = FrequencyEstimateQualification::Unavailable;
@@ -179,8 +183,10 @@ GpioFrequencyCorrection select_gpio_frequency_correction(
     result.qualification = estimate.qualification;
     result.provider_name = estimate.provider_name;
     result.source_provenance = estimate.source_provenance;
+    result.source_signature = estimate.source_signature;
     result.reason = estimate.reason;
     result.estimate_age_seconds = estimate.age_seconds;
+    result.snapshot_time = estimate.snapshot_time;
     result.residual_ppm = residual_ppm;
 
     if (use_estimate && estimate.frequency_ppm.has_value() &&

--- a/src/system_clock_frequency_estimate.cpp
+++ b/src/system_clock_frequency_estimate.cpp
@@ -282,8 +282,11 @@ GpioFrequencyCorrectionComposition compose_gpio_frequency_correction(
         return result;
     }
 
-    result.effective_ppm = intrinsic_ppm + selected_additional.effective_ppm;
-    if (!finite_bounded(result.effective_ppm))
+    const auto composition = wsprrypi::composeLegacyGpioCorrection(
+        intrinsic_ppm,
+        selected_additional.effective_ppm);
+    result.effective_ppm = composition.effective_ppm;
+    if (!composition.valid)
     {
         result.reason =
             "Intrinsic plus additional GPIO correction is outside +/-200 PPM.";

--- a/src/system_clock_frequency_estimate.cpp
+++ b/src/system_clock_frequency_estimate.cpp
@@ -7,7 +7,17 @@ namespace
 {
 bool finite_bounded(double value)
 {
-    return std::isfinite(value) && value >= -200.0 && value <= 200.0;
+    return std::isfinite(value) &&
+        value >= -kMaximumGpioFrequencyCorrectionPpm &&
+        value <= kMaximumGpioFrequencyCorrectionPpm;
+}
+
+GpioFrequencyCorrection invalid_correction(std::string reason)
+{
+    GpioFrequencyCorrection result;
+    result.valid = false;
+    result.reason = std::move(reason);
+    return result;
 }
 }
 
@@ -34,9 +44,43 @@ SystemClockFrequencyEstimate FrequencyEstimateQualifier::evaluate(
         attach_stale_fallback();
         return sample;
     }
+    if (!std::isfinite(sample.age_seconds) || sample.age_seconds < 0.0)
+    {
+        sample.reason = "Provider estimate age is malformed.";
+        attach_stale_fallback();
+        return sample;
+    }
+    if (!std::isfinite(sample.source_stability_span_seconds) ||
+        sample.source_stability_span_seconds < 0.0)
+    {
+        sample.reason = "Provider source stability span is malformed.";
+        attach_stale_fallback();
+        return sample;
+    }
+    if (!sample.skew_ppm.has_value() || !std::isfinite(*sample.skew_ppm) ||
+        *sample.skew_ppm < 0.0)
+    {
+        sample.reason = "Provider skew metadata is malformed.";
+        attach_stale_fallback();
+        return sample;
+    }
+    if (!sample.residual_frequency_ppm.has_value() ||
+        !std::isfinite(*sample.residual_frequency_ppm))
+    {
+        sample.reason = "Provider residual-frequency metadata is malformed.";
+        attach_stale_fallback();
+        return sample;
+    }
+
     if (!sample.synchronized || !sample.selected_source || !sample.leap_normal)
     {
         sample.reason = "Provider is not synchronized to a selected source with normal leap status.";
+        attach_stale_fallback();
+        return sample;
+    }
+    if (sample.source_signature.empty())
+    {
+        sample.reason = "Provider source signature is missing.";
         attach_stale_fallback();
         return sample;
     }
@@ -46,25 +90,14 @@ SystemClockFrequencyEstimate FrequencyEstimateQualifier::evaluate(
         attach_stale_fallback();
         return sample;
     }
-    if (sample.age_seconds > kCurrentMaximumAgeSeconds)
-    {
-        sample.qualification = FrequencyEstimateQualification::Stale;
-        sample.reason = "The last qualified provider estimate is stale.";
-        sample.last_qualified_frequency_ppm = sample.frequency_ppm;
-        sample.last_qualified_age_seconds = sample.age_seconds;
-        return sample;
-    }
-    if (!sample.skew_ppm.has_value() || !std::isfinite(*sample.skew_ppm) ||
-        *sample.skew_ppm > kMaximumSkewPpm)
+    if (*sample.skew_ppm > kMaximumSkewPpm)
     {
         sample.qualification = FrequencyEstimateQualification::Converging;
         sample.reason = "Provider skew exceeds the qualification limit.";
         attach_stale_fallback();
         return sample;
     }
-    if (!sample.residual_frequency_ppm.has_value() ||
-        !std::isfinite(*sample.residual_frequency_ppm) ||
-        std::abs(*sample.residual_frequency_ppm) > kMaximumResidualFrequencyPpm)
+    if (std::abs(*sample.residual_frequency_ppm) > kMaximumResidualFrequencyPpm)
     {
         sample.qualification = FrequencyEstimateQualification::Converging;
         sample.reason = "Provider residual frequency exceeds the qualification limit.";
@@ -79,7 +112,16 @@ SystemClockFrequencyEstimate FrequencyEstimateQualifier::evaluate(
         return sample;
     }
 
-    if (sample.source_signature.empty() || sample.source_signature != source_signature_)
+    if (sample.age_seconds > kCurrentMaximumAgeSeconds)
+    {
+        sample.qualification = FrequencyEstimateQualification::Stale;
+        sample.reason = "The provider estimate is stale.";
+        sample.last_qualified_frequency_ppm = sample.frequency_ppm;
+        sample.last_qualified_age_seconds = sample.age_seconds;
+        return sample;
+    }
+
+    if (sample.source_signature != source_signature_)
     {
         source_signature_ = sample.source_signature;
         frequency_history_.clear();
@@ -122,6 +164,17 @@ GpioFrequencyCorrection select_gpio_frequency_correction(
     double manual_ppm,
     const SystemClockFrequencyEstimate &estimate)
 {
+    if (!finite_bounded(residual_ppm))
+    {
+        return invalid_correction(
+            "Configured GPIO conducted residual PPM is non-finite or outside +/-200.");
+    }
+    if (!finite_bounded(manual_ppm))
+    {
+        return invalid_correction(
+            "Configured GPIO manual PPM is non-finite or outside +/-200.");
+    }
+
     GpioFrequencyCorrection result;
     result.qualification = estimate.qualification;
     result.provider_name = estimate.provider_name;
@@ -133,8 +186,18 @@ GpioFrequencyCorrection select_gpio_frequency_correction(
     if (use_estimate && estimate.frequency_ppm.has_value() &&
         estimate.qualification == FrequencyEstimateQualification::Qualified)
     {
+        if (!finite_bounded(*estimate.frequency_ppm))
+        {
+            return invalid_correction(
+                "Qualified provider estimate PPM is non-finite or outside +/-200.");
+        }
         result.estimate_ppm = estimate.frequency_ppm;
         result.effective_ppm = *estimate.frequency_ppm + residual_ppm;
+        if (!finite_bounded(result.effective_ppm))
+        {
+            return invalid_correction(
+                "Qualified provider estimate plus conducted residual is outside +/-200 PPM.");
+        }
         result.mode = GpioCorrectionMode::QualifiedEstimate;
         return result;
     }
@@ -145,11 +208,29 @@ GpioFrequencyCorrection select_gpio_frequency_correction(
             : estimate.last_qualified_frequency_ppm;
     if (use_estimate && stale_estimate.has_value())
     {
+        if (!finite_bounded(*stale_estimate))
+        {
+            return invalid_correction(
+                "Stale provider estimate PPM is non-finite or outside +/-200.");
+        }
+        const double stale_age =
+            estimate.qualification == FrequencyEstimateQualification::Stale
+                ? estimate.age_seconds
+                : estimate.last_qualified_age_seconds;
+        if (!std::isfinite(stale_age) || stale_age < 0.0 ||
+            stale_age > FrequencyEstimateQualifier::kStaleMaximumAgeSeconds)
+        {
+            return invalid_correction(
+                "Stale provider estimate age is malformed or expired.");
+        }
         result.estimate_ppm = stale_estimate;
-        result.estimate_age_seconds = estimate.qualification == FrequencyEstimateQualification::Stale
-            ? estimate.age_seconds
-            : estimate.last_qualified_age_seconds;
+        result.estimate_age_seconds = stale_age;
         result.effective_ppm = *stale_estimate + residual_ppm;
+        if (!finite_bounded(result.effective_ppm))
+        {
+            return invalid_correction(
+                "Stale provider estimate plus conducted residual is outside +/-200 PPM.");
+        }
         result.mode = GpioCorrectionMode::StaleEstimate;
         return result;
     }
@@ -170,6 +251,46 @@ GpioFrequencyCorrection select_gpio_frequency_correction(
     result.effective_ppm = 0.0;
     result.mode = GpioCorrectionMode::Uncalibrated;
     result.reason = "No valid provider estimate or fixed manual correction is available.";
+    return result;
+}
+
+GpioFrequencyCorrectionComposition compose_gpio_frequency_correction(
+    double intrinsic_ppm,
+    const GpioFrequencyCorrection &selected_additional)
+{
+    GpioFrequencyCorrectionComposition result;
+    result.intrinsic_ppm = intrinsic_ppm;
+    result.additional_ppm = selected_additional.effective_ppm;
+
+    if (!selected_additional.valid)
+    {
+        result.reason = selected_additional.reason.empty()
+            ? "Selected additional GPIO correction is invalid."
+            : selected_additional.reason;
+        return result;
+    }
+    if (!finite_bounded(intrinsic_ppm))
+    {
+        result.reason =
+            "Intrinsic GPIO system-to-RF difference is non-finite or outside +/-200 PPM.";
+        return result;
+    }
+    if (!finite_bounded(selected_additional.effective_ppm))
+    {
+        result.reason =
+            "Selected additional GPIO correction is non-finite or outside +/-200 PPM.";
+        return result;
+    }
+
+    result.effective_ppm = intrinsic_ppm + selected_additional.effective_ppm;
+    if (!finite_bounded(result.effective_ppm))
+    {
+        result.reason =
+            "Intrinsic plus additional GPIO correction is outside +/-200 PPM.";
+        return result;
+    }
+
+    result.valid = true;
     return result;
 }
 

--- a/src/system_clock_frequency_estimate.hpp
+++ b/src/system_clock_frequency_estimate.hpp
@@ -45,6 +45,7 @@ struct SystemClockFrequencyEstimate
     bool leap_normal = false;
     std::string source_provenance;
     std::string source_signature;
+    std::chrono::system_clock::time_point snapshot_time{};
     std::size_t retained_source_samples = 0;
     double source_stability_span_seconds = 0.0;
     std::string reason;
@@ -57,6 +58,7 @@ struct GpioFrequencyCorrection
     GpioCorrectionMode mode = GpioCorrectionMode::Uncalibrated;
     std::string provider_name;
     std::string source_provenance;
+    std::string source_signature;
     std::string reason;
     std::optional<double> estimate_ppm;
     double residual_ppm = 0.0;
@@ -64,6 +66,7 @@ struct GpioFrequencyCorrection
     double additional_ppm = 0.0;
     double effective_ppm = 0.0;
     double estimate_age_seconds = 0.0;
+    std::chrono::system_clock::time_point snapshot_time{};
 };
 
 struct GpioFrequencyCorrectionComposition

--- a/src/system_clock_frequency_estimate.hpp
+++ b/src/system_clock_frequency_estimate.hpp
@@ -24,6 +24,8 @@ enum class GpioCorrectionMode
     Uncalibrated
 };
 
+inline constexpr double kMaximumGpioFrequencyCorrectionPpm = 200.0;
+
 struct SystemClockFrequencyEstimate
 {
     std::string provider_name;
@@ -47,6 +49,7 @@ struct SystemClockFrequencyEstimate
 
 struct GpioFrequencyCorrection
 {
+    bool valid = true;
     FrequencyEstimateQualification qualification = FrequencyEstimateQualification::Unavailable;
     GpioCorrectionMode mode = GpioCorrectionMode::Uncalibrated;
     std::string provider_name;
@@ -56,6 +59,15 @@ struct GpioFrequencyCorrection
     double residual_ppm = 0.0;
     double effective_ppm = 0.0;
     double estimate_age_seconds = 0.0;
+};
+
+struct GpioFrequencyCorrectionComposition
+{
+    bool valid = false;
+    double intrinsic_ppm = 0.0;
+    double additional_ppm = 0.0;
+    double effective_ppm = 0.0;
+    std::string reason;
 };
 
 class FrequencyEstimateQualifier
@@ -84,6 +96,10 @@ GpioFrequencyCorrection select_gpio_frequency_correction(
     double residual_ppm,
     double manual_ppm,
     const SystemClockFrequencyEstimate &estimate);
+
+GpioFrequencyCorrectionComposition compose_gpio_frequency_correction(
+    double intrinsic_ppm,
+    const GpioFrequencyCorrection &selected_additional);
 
 const char *to_string(FrequencyEstimateQualification value) noexcept;
 const char *to_string(GpioCorrectionMode value) noexcept;

--- a/src/system_clock_frequency_estimate.hpp
+++ b/src/system_clock_frequency_estimate.hpp
@@ -8,6 +8,8 @@
 #include <string>
 #include <vector>
 
+#include "WSPR-Transmitter/src/legacy_gpio_clock_model.hpp"
+
 enum class FrequencyEstimateQualification
 {
     Qualified,
@@ -24,7 +26,8 @@ enum class GpioCorrectionMode
     Uncalibrated
 };
 
-inline constexpr double kMaximumGpioFrequencyCorrectionPpm = 200.0;
+inline constexpr double kMaximumGpioFrequencyCorrectionPpm =
+    wsprrypi::kMaximumLegacyGpioCorrectionPpm;
 
 struct SystemClockFrequencyEstimate
 {
@@ -57,6 +60,8 @@ struct GpioFrequencyCorrection
     std::string reason;
     std::optional<double> estimate_ppm;
     double residual_ppm = 0.0;
+    double intrinsic_ppm = 0.0;
+    double additional_ppm = 0.0;
     double effective_ppm = 0.0;
     double estimate_age_seconds = 0.0;
 };

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -1248,11 +1248,11 @@ int main(int argc, char *argv[])
                 provenance.gpio_correction_candidate.nominal_rate_hz == 750000000.0 &&
                 nearly_equal(
                     provenance.gpio_correction_candidate.intrinsic_ppm,
-                    0.153768,
+                    0.0,
                     1.0e-9) &&
                 nearly_equal(
                     provenance.gpio_correction_candidate.final_ppm,
-                    0.153768,
+                    0.0,
                     1.0e-9),
             "candidate provenance must expose the exact planned BCM2711 parent and correction");
         require(
@@ -1263,11 +1263,11 @@ int main(int argc, char *argv[])
                 provenance.gpio_correction_committed.nominal_rate_hz == 750000000.0 &&
                 nearly_equal(
                     provenance.gpio_correction_committed.intrinsic_ppm,
-                    0.153768,
+                    0.0,
                     1.0e-9) &&
                 nearly_equal(
                     provenance.gpio_correction_committed.final_ppm,
-                    0.153768,
+                    0.0,
                     1.0e-9) &&
                 !provenance.gpio_correction_committed.execution_identity.empty(),
             "committed provenance must freeze exact plan identity without claiming idle work is active");
@@ -1297,7 +1297,7 @@ int main(int argc, char *argv[])
         const auto bcm2711_legacy_request = current_transmission_request_for_test();
         const auto bcm2711_2200m_provenance = current_tx_runtime_status_snapshot();
         require(
-            nearly_equal(bcm2711_legacy_request.ppm, -15.035290) &&
+            nearly_equal(bcm2711_legacy_request.ppm, 0.0) &&
                 bcm2711_2200m_provenance.gpio_correction_candidate.available &&
                 bcm2711_2200m_provenance.gpio_correction_candidate.selected_parent ==
                     "oscillator" &&
@@ -1305,11 +1305,11 @@ int main(int argc, char *argv[])
                     54000000.0 &&
                 nearly_equal(
                     bcm2711_2200m_provenance.gpio_correction_candidate.intrinsic_ppm,
-                    -15.035290) &&
+                    0.0) &&
                 nearly_equal(
                     bcm2711_2200m_provenance.gpio_correction_candidate.final_ppm,
-                    -15.035290),
-            "BCM2711 2200 m planning must commit and publish the promoted oscillator intrinsic value");
+                    0.0),
+            "BCM2711 2200 m planning must commit and publish the conservative oscillator zero baseline");
         auto bcm2711_request = controller_request_from_legacy_for_test(
             bcm2711_legacy_request,
             wsprrypi::TransmissionMode::WSPR);

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -1272,7 +1272,7 @@ int main(int argc, char *argv[])
             !bcm2711_request.policy.allow_unqualified_frequency &&
                 !bcm2711_request.policy.allow_non_amateur_frequency &&
                 bcm2711_request.policy.hardware_profile ==
-                    wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD &&
+                    wsprrypi::HardwareProfile::BCM2711 &&
                 wsprrypi::evaluate_gpio_band_policy(
                     wsprrypi::ExecutionPlanCompiler{}.compile(bcm2711_request)).allowed,
             "direct WSPR controller requests must preserve the qualified BCM2711 2200 m profile");
@@ -1303,7 +1303,7 @@ int main(int argc, char *argv[])
             legacy_override_request.policy.allow_unqualified_frequency &&
                 !legacy_override_request.policy.allow_non_amateur_frequency &&
                 legacy_override_request.policy.hardware_profile ==
-                    wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD &&
+                    wsprrypi::HardwareProfile::BCM2836_BCM2837 &&
                 wsprrypi::evaluate_gpio_band_policy(
                     wsprrypi::ExecutionPlanCompiler{}.compile(legacy_override_request)).allowed,
             "direct WSPR controller requests must preserve the legacy unqualified-frequency override");

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -1295,6 +1295,21 @@ int main(int argc, char *argv[])
             set_config(true),
             "BCM2711 2200 m WSPR regression must plan a scheduler request");
         const auto bcm2711_legacy_request = current_transmission_request_for_test();
+        const auto bcm2711_2200m_provenance = current_tx_runtime_status_snapshot();
+        require(
+            nearly_equal(bcm2711_legacy_request.ppm, -15.035290) &&
+                bcm2711_2200m_provenance.gpio_correction_candidate.available &&
+                bcm2711_2200m_provenance.gpio_correction_candidate.selected_parent ==
+                    "oscillator" &&
+                bcm2711_2200m_provenance.gpio_correction_candidate.nominal_rate_hz ==
+                    54000000.0 &&
+                nearly_equal(
+                    bcm2711_2200m_provenance.gpio_correction_candidate.intrinsic_ppm,
+                    -15.035290) &&
+                nearly_equal(
+                    bcm2711_2200m_provenance.gpio_correction_candidate.final_ppm,
+                    -15.035290),
+            "BCM2711 2200 m planning must commit and publish the promoted oscillator intrinsic value");
         auto bcm2711_request = controller_request_from_legacy_for_test(
             bcm2711_legacy_request,
             wsprrypi::TransmissionMode::WSPR);

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -1372,6 +1372,64 @@ int main(int argc, char *argv[])
             validate_config_candidate(config, &validation_error),
             "GPIO4 must be accepted on Raspberry Pi 5 when the RP1 provider is available");
 
+        config.gpio_use_system_clock_frequency_estimate = false;
+        config.use_system_clock_frequency_estimate = false;
+        config.gpio_manual_ppm = 12.5;
+        reset_runtime_planning_state_for_identity_test();
+        require(
+            set_config(true),
+            "RP1 scheduler must accept a manual GPIO correction");
+        auto rp1_manual_request = current_transmission_request_for_test();
+        auto rp1_manual_provenance = current_tx_runtime_status_snapshot();
+        require(
+            nearly_equal(rp1_manual_request.ppm, 12.5) &&
+                rp1_manual_provenance.gpio_correction_committed.available &&
+                rp1_manual_provenance.gpio_correction_committed.processor_profile ==
+                    "RP1" &&
+                rp1_manual_provenance.gpio_correction_committed.selected_parent ==
+                    "PLL_SYS" &&
+                nearly_equal(
+                    rp1_manual_provenance.gpio_correction_committed.nominal_rate_hz,
+                    200000000.0) &&
+                nearly_equal(
+                    rp1_manual_provenance.gpio_correction_committed.intrinsic_ppm,
+                    0.0) &&
+                nearly_equal(
+                    rp1_manual_provenance.gpio_correction_committed.final_ppm,
+                    12.5),
+            "RP1 must freeze its zero intrinsic residual plus one manual correction");
+        finish_runtime_planning_state_for_identity_test();
+
+        SystemClockFrequencyEstimate rp1_estimate;
+        rp1_estimate.provider_name = "chrony";
+        rp1_estimate.qualification = FrequencyEstimateQualification::Qualified;
+        rp1_estimate.frequency_ppm = 10.0;
+        rp1_estimate.synchronized = true;
+        rp1_estimate.selected_source = true;
+        rp1_estimate.leap_normal = true;
+        config.gpio_use_system_clock_frequency_estimate = true;
+        config.use_system_clock_frequency_estimate = true;
+        config.gpio_frequency_residual_ppm = 1.25;
+        set_current_frequency_estimate_for_test(rp1_estimate);
+        reset_runtime_planning_state_for_identity_test();
+        require(
+            set_config(true),
+            "RP1 scheduler must accept a qualified system-clock estimate");
+        const auto rp1_estimate_request = current_transmission_request_for_test();
+        const auto rp1_estimate_provenance = current_tx_runtime_status_snapshot();
+        require(
+            nearly_equal(rp1_estimate_request.ppm, 11.25) &&
+                nearly_equal(
+                    rp1_estimate_provenance.gpio_correction_committed
+                        .conducted_residual_ppm,
+                    1.25) &&
+                nearly_equal(
+                    rp1_estimate_provenance.gpio_correction_committed.final_ppm,
+                    11.25),
+            "RP1 must freeze its zero intrinsic residual plus qualified estimate and conducted residual");
+        finish_runtime_planning_state_for_identity_test();
+        set_current_frequency_estimate_for_test(SystemClockFrequencyEstimate{});
+
         PreparedConfigCandidate candidate;
         auto managed_rp1_ini =
             make_managed_ini_data("AA0NT", "EM18", "20m", true);

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -1240,8 +1240,28 @@ int main(int argc, char *argv[])
         require(
             current_transmission_request_for_test().mode == TransmissionMode::WSPR,
             "scheduler must commit a normal WSPR request for GPIO on Raspberry Pi 4");
+        const auto provenance = current_tx_runtime_status_snapshot();
+        require(
+            provenance.gpio_correction_candidate.available &&
+                provenance.gpio_correction_candidate.processor_profile == "BCM2711" &&
+                provenance.gpio_correction_candidate.selected_parent == "PLLD" &&
+                provenance.gpio_correction_candidate.nominal_rate_hz == 750000000.0 &&
+                provenance.gpio_correction_candidate.final_ppm == 0.0,
+            "candidate provenance must expose the exact planned BCM2711 parent and correction");
+        require(
+            provenance.gpio_correction_committed.available &&
+                !provenance.gpio_correction_committed.active &&
+                provenance.gpio_correction_committed.processor_profile == "BCM2711" &&
+                provenance.gpio_correction_committed.selected_parent == "PLLD" &&
+                provenance.gpio_correction_committed.nominal_rate_hz == 750000000.0 &&
+                !provenance.gpio_correction_committed.execution_identity.empty(),
+            "committed provenance must freeze exact plan identity without claiming idle work is active");
 
         finish_runtime_planning_state_for_identity_test();
+        reset_current_transmission_request_for_test();
+        require(
+            !current_tx_runtime_status_snapshot().gpio_correction_committed.available,
+            "cleared execution state must not expose stale committed provenance");
         clear_pi_generation_override_for_scope();
     }
 

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -1246,7 +1246,14 @@ int main(int argc, char *argv[])
                 provenance.gpio_correction_candidate.processor_profile == "BCM2711" &&
                 provenance.gpio_correction_candidate.selected_parent == "PLLD" &&
                 provenance.gpio_correction_candidate.nominal_rate_hz == 750000000.0 &&
-                provenance.gpio_correction_candidate.final_ppm == 0.0,
+                nearly_equal(
+                    provenance.gpio_correction_candidate.intrinsic_ppm,
+                    0.153768,
+                    1.0e-9) &&
+                nearly_equal(
+                    provenance.gpio_correction_candidate.final_ppm,
+                    0.153768,
+                    1.0e-9),
             "candidate provenance must expose the exact planned BCM2711 parent and correction");
         require(
             provenance.gpio_correction_committed.available &&
@@ -1254,6 +1261,14 @@ int main(int argc, char *argv[])
                 provenance.gpio_correction_committed.processor_profile == "BCM2711" &&
                 provenance.gpio_correction_committed.selected_parent == "PLLD" &&
                 provenance.gpio_correction_committed.nominal_rate_hz == 750000000.0 &&
+                nearly_equal(
+                    provenance.gpio_correction_committed.intrinsic_ppm,
+                    0.153768,
+                    1.0e-9) &&
+                nearly_equal(
+                    provenance.gpio_correction_committed.final_ppm,
+                    0.153768,
+                    1.0e-9) &&
                 !provenance.gpio_correction_committed.execution_identity.empty(),
             "committed provenance must freeze exact plan identity without claiming idle work is active");
 
@@ -2844,7 +2859,7 @@ int main(int argc, char *argv[])
                 nearly_equal(first_request.actual_rf_frequency_hz, 10140200.0),
             "runtime repeated skip regression must start on the valid 30m slot");
         require(
-            nearly_equal(first_request.ppm, 12.5),
+            nearly_equal(first_request.ppm, 12.653768),
             "runtime repeated skip regression must snapshot PPM into the committed 30m request");
         require(
             first_request.hasSelectorGPIO() &&
@@ -2872,7 +2887,7 @@ int main(int argc, char *argv[])
                 nearly_equal(first_skip_request.actual_rf_frequency_hz, 0.0),
             "runtime repeated skip regression must commit the first 0 Hz slot as a skip-window request");
         require(
-            nearly_equal(first_skip_request.ppm, 12.5),
+            nearly_equal(first_skip_request.ppm, 12.653768),
             "runtime repeated skip regression must snapshot PPM into committed skip requests");
         require(
             !first_skip_request.hasSelectorGPIO(),
@@ -2935,7 +2950,7 @@ int main(int argc, char *argv[])
                 nearly_equal(wrapped_request.actual_rf_frequency_hz, 10140200.0),
             "runtime repeated skip regression must wrap back to the valid 30m slot after three skips");
         require(
-            nearly_equal(wrapped_request.ppm, 12.5),
+            nearly_equal(wrapped_request.ppm, 12.653768),
             "runtime repeated skip regression must preserve the committed PPM snapshot when the valid slot resumes");
         require(
             wrapped_request.hasSelectorGPIO() &&
@@ -3910,7 +3925,7 @@ int main(int argc, char *argv[])
         set_frequencies(config);
 
         ppm_reload_pending.store(true, std::memory_order_relaxed);
-        const double expected_ppm = 12.5;
+        const double expected_ppm = 12.653768;
 
         require(
             set_config(true),
@@ -5639,8 +5654,8 @@ int main(int argc, char *argv[])
         const TransmissionRequest residual_tone_request =
             current_transmission_request_for_test();
         require(
-            nearly_equal(residual_tone_request.ppm, 12.073) &&
-                nearly_equal(config.ppm, 12.073),
+            nearly_equal(residual_tone_request.ppm, 12.226768) &&
+                nearly_equal(config.ppm, 12.226768),
             "GPIO test tone commit must select the current estimate plus residual instead of a stale cached PPM");
         require(
             end_test_tone().stopped,

--- a/src/tests/gpio_band_policy_test.cpp
+++ b/src/tests/gpio_band_policy_test.cpp
@@ -321,12 +321,12 @@ int main()
         wsprrypi::BackendKind::RPI_CLOCK_GPIO,
         wsprrypi::TransmissionMode::WSPR,
         137500.0, false, "legacy 2200 m profile", false, false,
-        wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
+        wsprrypi::HardwareProfile::BCM2836_BCM2837);
     require_controller_policy(
         wsprrypi::BackendKind::RPI_CLOCK_GPIO,
         wsprrypi::TransmissionMode::TONE,
         137500.0, true, "legacy 2200 m TONE profile", false, false,
-        wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
+        wsprrypi::HardwareProfile::BCM2836_BCM2837);
     for (const auto qualified_mode : {
              wsprrypi::TransmissionMode::QRSS,
              wsprrypi::TransmissionMode::FSKCW,
@@ -338,7 +338,7 @@ int main()
             137500.0,
             false,
             false,
-            wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
+            wsprrypi::HardwareProfile::BCM2836_BCM2837);
         require(
             decision.qualification == wsprrypi::QualificationState::QUALIFIED,
             "legacy 2200 m qualified CW mode must retain qualified state");
@@ -346,13 +346,13 @@ int main()
             wsprrypi::BackendKind::RPI_CLOCK_GPIO,
             qualified_mode,
             137500.0, true, "legacy 2200 m qualified CW profile", false, false,
-            wsprrypi::HardwareProfile::LEGACY_500_MHZ_PLLD);
+            wsprrypi::HardwareProfile::BCM2836_BCM2837);
     }
     require_controller_policy(
         wsprrypi::BackendKind::RPI_CLOCK_GPIO,
         wsprrypi::TransmissionMode::WSPR,
         137500.0, true, "BCM2711 2200 m profile", false, false,
-        wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD);
+        wsprrypi::HardwareProfile::BCM2711);
 
     for (const auto mode : {
              wsprrypi::TransmissionMode::TONE,
@@ -364,20 +364,20 @@ int main()
             wsprrypi::BackendKind::RPI_CLOCK_GPIO,
             mode,
             50294500.0, true, "BCM2711 6 m qualified CW profile", false, false,
-            wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD);
+            wsprrypi::HardwareProfile::BCM2711);
     }
     require_controller_policy(
         wsprrypi::BackendKind::RPI_CLOCK_GPIO,
         wsprrypi::TransmissionMode::WSPR,
         50294500.0, false, "BCM2711 6 m WSPR profile", false, false,
-        wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD);
+        wsprrypi::HardwareProfile::BCM2711);
     for (const double unavailable_frequency : {222101500.0, 432301500.0})
     {
         require_controller_policy(
             wsprrypi::BackendKind::RPI_CLOCK_GPIO,
             wsprrypi::TransmissionMode::TONE,
             unavailable_frequency, false, "BCM2711 unavailable profile", true, true,
-            wsprrypi::HardwareProfile::BCM2711_750_MHZ_PLLD);
+            wsprrypi::HardwareProfile::BCM2711);
     }
 
     for (const auto mode : exercised_modes)

--- a/src/tests/gpio_frequency_correction_test.cpp
+++ b/src/tests/gpio_frequency_correction_test.cpp
@@ -1,0 +1,295 @@
+#include "system_clock_frequency_estimate.hpp"
+#include "WSPR-Transmitter/src/transmission_request.hpp"
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <string>
+
+namespace
+{
+    int failures = 0;
+
+    void expect(bool condition, const std::string& message)
+    {
+        if (!condition)
+        {
+            std::cerr << "FAIL: " << message << '\n';
+            ++failures;
+        }
+    }
+
+    SystemClockFrequencyEstimate provider(
+        double frequency_ppm,
+        FrequencyEstimateQualification qualification =
+            FrequencyEstimateQualification::Qualified)
+    {
+        SystemClockFrequencyEstimate value;
+        value.provider_name = "chrony";
+        value.qualification = qualification;
+        value.frequency_ppm = frequency_ppm;
+        value.age_seconds = 2.0;
+        value.synchronized = true;
+        value.selected_source = true;
+        value.leap_normal = true;
+        value.skew_ppm = 0.2;
+        value.residual_frequency_ppm = 0.05;
+        value.source_signature = "ntp.example";
+        value.retained_source_samples = 8;
+        value.source_stability_span_seconds = 512.0;
+        return value;
+    }
+
+    void testFinalSelectionBounds()
+    {
+        const auto positive_boundary = select_gpio_frequency_correction(
+            true, 1.0, 0.0, provider(199.0));
+        const auto negative_boundary = select_gpio_frequency_correction(
+            true, -1.0, 0.0, provider(-199.0));
+        expect(
+            positive_boundary.valid && positive_boundary.effective_ppm == 200.0,
+            "qualified provider composition must accept the exact +200 PPM boundary");
+        expect(
+            negative_boundary.valid && negative_boundary.effective_ppm == -200.0,
+            "qualified provider composition must accept the exact -200 PPM boundary");
+
+        const auto positive_overflow = select_gpio_frequency_correction(
+            true, 2.0, 0.0, provider(199.0));
+        const auto negative_overflow = select_gpio_frequency_correction(
+            true, -2.0, 0.0, provider(-199.0));
+        expect(
+            !positive_overflow.valid && positive_overflow.effective_ppm == 0.0,
+            "199 + 2 PPM must fail before producing a committed correction");
+        expect(
+            !negative_overflow.valid && negative_overflow.effective_ppm == 0.0,
+            "-199 - 2 PPM must fail before producing a committed correction");
+
+        for (const double invalid : {
+                 200.000001,
+                 -200.000001,
+                 std::numeric_limits<double>::infinity(),
+                 -std::numeric_limits<double>::infinity(),
+                 std::numeric_limits<double>::quiet_NaN()})
+        {
+            expect(
+                !select_gpio_frequency_correction(
+                     true, invalid, 0.0, provider(0.0)).valid,
+                "invalid conducted residual must fail explicitly");
+            expect(
+                !select_gpio_frequency_correction(
+                     false, 0.0, invalid, provider(0.0)).valid,
+                "invalid manual correction must fail explicitly");
+        }
+
+        expect(
+            !select_gpio_frequency_correction(
+                 true, 0.0, 0.0, provider(200.000001)).valid,
+            "out-of-range qualified provider data must fail explicitly");
+        auto invalid_stale = provider(
+            -200.000001,
+            FrequencyEstimateQualification::Stale);
+        invalid_stale.age_seconds = 600.0;
+        expect(
+            !select_gpio_frequency_correction(
+                 true, 0.0, 0.0, invalid_stale).valid,
+            "out-of-range stale provider data must fail explicitly");
+    }
+
+    void testProviderMetadataValidation()
+    {
+        auto evaluate_once = [](SystemClockFrequencyEstimate sample) {
+            FrequencyEstimateQualifier qualifier;
+            return qualifier.evaluate(std::move(sample));
+        };
+
+        for (const double invalid : {
+                 -1.0,
+                 std::numeric_limits<double>::infinity(),
+                 std::numeric_limits<double>::quiet_NaN()})
+        {
+            auto bad_age = provider(1.0);
+            bad_age.age_seconds = invalid;
+            const auto age_result = evaluate_once(bad_age);
+            expect(
+                age_result.qualification ==
+                        FrequencyEstimateQualification::Unavailable &&
+                    age_result.reason.find("age is malformed") !=
+                        std::string::npos,
+                "negative or non-finite provider age must be rejected as malformed");
+
+            auto bad_span = provider(1.0);
+            bad_span.source_stability_span_seconds = invalid;
+            const auto span_result = evaluate_once(bad_span);
+            expect(
+                span_result.qualification ==
+                        FrequencyEstimateQualification::Unavailable &&
+                    span_result.reason.find("stability span is malformed") !=
+                        std::string::npos,
+                "negative or non-finite stability span must be rejected as malformed");
+        }
+
+        auto negative_skew = provider(1.0);
+        negative_skew.skew_ppm = -0.01;
+        const auto negative_skew_result = evaluate_once(negative_skew);
+        expect(
+            negative_skew_result.qualification ==
+                    FrequencyEstimateQualification::Unavailable &&
+                negative_skew_result.reason.find("skew metadata is malformed") !=
+                    std::string::npos,
+            "negative skew must not pass provider qualification");
+
+        negative_skew.age_seconds = 600.0;
+        const auto stale_negative_skew_result = evaluate_once(negative_skew);
+        expect(
+            stale_negative_skew_result.qualification ==
+                    FrequencyEstimateQualification::Unavailable &&
+                stale_negative_skew_result.reason.find(
+                    "skew metadata is malformed") != std::string::npos,
+            "stale age must not bypass malformed skew validation");
+
+        auto high_skew = provider(1.0);
+        high_skew.skew_ppm = 1.01;
+        const auto high_skew_result = evaluate_once(high_skew);
+        expect(
+            high_skew_result.qualification ==
+                FrequencyEstimateQualification::Converging,
+            "finite positive skew above the limit must remain a convergence condition");
+        high_skew.age_seconds = 600.0;
+        expect(
+            evaluate_once(high_skew).qualification ==
+                FrequencyEstimateQualification::Converging,
+            "stale age must not bypass the maximum skew quality gate");
+
+        auto nonfinite_residual = provider(1.0);
+        nonfinite_residual.residual_frequency_ppm =
+            std::numeric_limits<double>::quiet_NaN();
+        expect(
+            evaluate_once(nonfinite_residual).qualification ==
+                FrequencyEstimateQualification::Unavailable,
+            "non-finite provider residual metadata must be rejected");
+        nonfinite_residual.age_seconds = 600.0;
+        expect(
+            evaluate_once(nonfinite_residual).qualification ==
+                FrequencyEstimateQualification::Unavailable,
+            "stale age must not bypass malformed residual validation");
+
+        auto high_residual = provider(1.0);
+        high_residual.residual_frequency_ppm = 0.51;
+        high_residual.age_seconds = 600.0;
+        expect(
+            evaluate_once(high_residual).qualification ==
+                FrequencyEstimateQualification::Converging,
+            "stale age must not bypass the residual-frequency quality gate");
+
+        auto missing_signature = provider(1.0);
+        missing_signature.source_signature.clear();
+        expect(
+            evaluate_once(missing_signature).qualification ==
+                FrequencyEstimateQualification::Unavailable,
+            "missing source identity must be rejected explicitly");
+    }
+
+    void testFallbackExclusivityAndStaleValidation()
+    {
+        const auto qualified = select_gpio_frequency_correction(
+            true, 0.25, 8.0, provider(1.0));
+        expect(
+            qualified.valid &&
+                qualified.mode == GpioCorrectionMode::QualifiedEstimate &&
+                qualified.effective_ppm == 1.25,
+            "qualified provider selection must exclude the configured manual fallback");
+
+        SystemClockFrequencyEstimate unavailable;
+        unavailable.qualification = FrequencyEstimateQualification::Unavailable;
+        unavailable.reason = "provider unavailable";
+        const auto manual = select_gpio_frequency_correction(
+            true, 0.25, -3.0, unavailable);
+        expect(
+            manual.valid && manual.mode == GpioCorrectionMode::FixedManual &&
+                manual.effective_ppm == -3.0,
+            "manual correction must be selected only when provider fallback is unavailable");
+
+        auto stale = provider(1.0, FrequencyEstimateQualification::Stale);
+        stale.age_seconds = 600.0;
+        const auto stale_selected = select_gpio_frequency_correction(
+            true, -0.25, 8.0, stale);
+        expect(
+            stale_selected.valid &&
+                stale_selected.mode == GpioCorrectionMode::StaleEstimate &&
+                stale_selected.effective_ppm == 0.75,
+            "usable stale provider data must exclude the manual fallback");
+
+        stale.age_seconds = -1.0;
+        expect(
+            !select_gpio_frequency_correction(true, 0.0, 8.0, stale).valid,
+            "malformed stale age must fail rather than silently selecting manual or zero");
+    }
+
+    void testIntrinsicCompositionAndFreezing()
+    {
+        const auto qualified = select_gpio_frequency_correction(
+            true, 0.25, 8.0, provider(1.0));
+
+        SystemClockFrequencyEstimate unavailable;
+        unavailable.qualification = FrequencyEstimateQualification::Unavailable;
+        const auto manual = select_gpio_frequency_correction(
+            true, 0.0, 3.0, unavailable);
+        const auto zero = select_gpio_frequency_correction(
+            true, 0.0, 0.0, unavailable);
+
+        const auto with_provider =
+            compose_gpio_frequency_correction(-2.5, qualified);
+        const auto with_manual =
+            compose_gpio_frequency_correction(-2.5, manual);
+        const auto with_zero =
+            compose_gpio_frequency_correction(-2.5, zero);
+        expect(
+            with_provider.valid && with_provider.effective_ppm == -1.25,
+            "BCM2835 intrinsic correction must remain active with provider correction");
+        expect(
+            with_manual.valid && with_manual.effective_ppm == 0.5,
+            "BCM2835 intrinsic correction must remain active with manual correction");
+        expect(
+            with_zero.valid && with_zero.effective_ppm == -2.5,
+            "BCM2835 intrinsic correction must remain active with zero additional correction");
+
+        GpioFrequencyCorrection upper;
+        upper.effective_ppm = 199.0;
+        expect(
+            !compose_gpio_frequency_correction(2.0, upper).valid,
+            "intrinsic plus additional correction must validate the final sum");
+        expect(
+            !compose_gpio_frequency_correction(
+                 std::numeric_limits<double>::infinity(), zero).valid,
+            "non-finite intrinsic correction must fail explicitly");
+        expect(
+            compose_gpio_frequency_correction(0.0, upper).valid,
+            "a bounded additional correction must remain valid without an intrinsic component");
+
+        wsprrypi::TransmissionRequest committed;
+        committed.calibration.ppm = with_provider.effective_ppm;
+        GpioFrequencyCorrection refreshed = qualified;
+        refreshed.effective_ppm = 9.0;
+        expect(
+            committed.calibration.ppm == -1.25 &&
+                refreshed.effective_ppm == 9.0,
+            "a committed request must freeze the complete correction scalar across provider refresh");
+    }
+}
+
+int main()
+{
+    testFinalSelectionBounds();
+    testProviderMetadataValidation();
+    testFallbackExclusivityAndStaleValidation();
+    testIntrinsicCompositionAndFreezing();
+
+    if (failures != 0)
+    {
+        std::cerr << failures << " GPIO frequency-correction test(s) failed\n";
+        return EXIT_FAILURE;
+    }
+    std::cout << "GPIO frequency-correction tests passed\n";
+    return EXIT_SUCCESS;
+}

--- a/src/tests/gpio_frequency_correction_test.cpp
+++ b/src/tests/gpio_frequency_correction_test.cpp
@@ -36,6 +36,8 @@ namespace
         value.skew_ppm = 0.2;
         value.residual_frequency_ppm = 0.05;
         value.source_signature = "ntp.example";
+        value.snapshot_time = std::chrono::system_clock::time_point{
+            std::chrono::seconds{1700000000}};
         value.retained_source_samples = 8;
         value.source_stability_span_seconds = 512.0;
         return value;
@@ -197,8 +199,11 @@ namespace
         expect(
             qualified.valid &&
                 qualified.mode == GpioCorrectionMode::QualifiedEstimate &&
-                qualified.effective_ppm == 1.25,
-            "qualified provider selection must exclude the configured manual fallback");
+                qualified.effective_ppm == 1.25 &&
+                qualified.source_signature == "ntp.example" &&
+                qualified.snapshot_time.time_since_epoch() ==
+                    std::chrono::seconds{1700000000},
+            "qualified provider selection must exclude manual fallback and retain snapshot identity");
 
         SystemClockFrequencyEstimate unavailable;
         unavailable.qualification = FrequencyEstimateQualification::Unavailable;
@@ -207,8 +212,8 @@ namespace
             true, 0.25, -3.0, unavailable);
         expect(
             manual.valid && manual.mode == GpioCorrectionMode::FixedManual &&
-                manual.effective_ppm == -3.0,
-            "manual correction must be selected only when provider fallback is unavailable");
+                manual.effective_ppm == -3.0 && manual.residual_ppm == 0.25,
+            "manual correction must remain exclusive while retaining the configured residual as unapplied provenance");
 
         auto stale = provider(1.0, FrequencyEstimateQualification::Stale);
         stale.age_seconds = 600.0;
@@ -224,6 +229,35 @@ namespace
         expect(
             !select_gpio_frequency_correction(true, 0.0, 8.0, stale).valid,
             "malformed stale age must fail rather than silently selecting manual or zero");
+    }
+
+    void testStaleFallbackRetainsQualifiedSnapshotIdentity()
+    {
+        FrequencyEstimateQualifier qualifier;
+        auto original = provider(1.0);
+        original.source_provenance = "original source";
+        SystemClockFrequencyEstimate qualified;
+        for (int i = 0; i < 3; ++i)
+            qualified = qualifier.evaluate(original);
+        expect(
+            qualified.qualification == FrequencyEstimateQualification::Qualified,
+            "stable provider fixture must qualify before fallback identity testing");
+
+        auto changed = provider(2.0);
+        changed.source_signature = "replacement.example";
+        changed.source_provenance = "replacement source";
+        changed.snapshot_time += std::chrono::hours{1};
+        changed.synchronized = false;
+        const auto fallback = qualifier.evaluate(changed);
+        const auto selected = select_gpio_frequency_correction(
+            true, 0.0, 0.0, fallback);
+        expect(
+            selected.mode == GpioCorrectionMode::StaleEstimate &&
+                selected.effective_ppm == 1.0 &&
+                selected.source_signature == "ntp.example" &&
+                selected.source_provenance == "original source" &&
+                selected.snapshot_time == original.snapshot_time,
+            "stale numeric fallback must retain the same qualified source identity and snapshot time");
     }
 
     void testIntrinsicCompositionAndFreezing()
@@ -283,6 +317,7 @@ int main()
     testFinalSelectionBounds();
     testProviderMetadataValidation();
     testFallbackExclusivityAndStaleValidation();
+    testStaleFallbackRetainsQualifiedSnapshotIdentity();
     testIntrinsicCompositionAndFreezing();
 
     if (failures != 0)

--- a/src/tests/mailbox_memory_flag_test.cpp
+++ b/src/tests/mailbox_memory_flag_test.cpp
@@ -1,0 +1,122 @@
+#include "Mailbox/src/mailbox_revision.hpp"
+
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <unistd.h>
+
+namespace
+{
+    class TemporaryCpuInfo
+    {
+    public:
+        TemporaryCpuInfo()
+        {
+            std::string pattern =
+                (std::filesystem::temp_directory_path() / "wsprrypi-cpuinfo-XXXXXX").string();
+            const int fd = mkstemp(pattern.data());
+            assert(fd >= 0);
+            assert(::close(fd) == 0);
+            path_ = std::move(pattern);
+        }
+
+        ~TemporaryCpuInfo()
+        {
+            std::error_code error;
+            std::filesystem::remove(path_, error);
+        }
+
+        const std::string &path() const { return path_; }
+
+        void write(const std::string &contents) const
+        {
+            std::ofstream output(path_, std::ios::trunc);
+            assert(output);
+            output << contents;
+            assert(output.good());
+        }
+
+        void remove() const
+        {
+            assert(std::filesystem::remove(path_));
+        }
+
+    private:
+        std::string path_;
+    };
+
+    void expectRuntimeError(
+        mailbox_detail::RevisionResolver &resolver,
+        const std::string &path,
+        const std::string &message_fragment)
+    {
+        try
+        {
+            (void)resolver.memoryFlagFromCpuInfo(path.c_str());
+            assert(false && "expected std::runtime_error");
+        }
+        catch (const std::runtime_error &error)
+        {
+            assert(std::string(error.what()).find(message_fragment) != std::string::npos);
+        }
+    }
+}
+
+int main()
+{
+    {
+        TemporaryCpuInfo cpuinfo;
+        cpuinfo.remove();
+        mailbox_detail::RevisionResolver resolver;
+        expectRuntimeError(resolver, cpuinfo.path(), "cannot open");
+        cpuinfo.write("Revision\t: 0002\n");
+        assert(resolver.memoryFlagFromCpuInfo(cpuinfo.path().c_str()) == 0x0CU);
+    }
+
+    {
+        TemporaryCpuInfo cpuinfo;
+        cpuinfo.write("Hardware\t: BCM2835\n");
+        mailbox_detail::RevisionResolver resolver;
+        expectRuntimeError(resolver, cpuinfo.path(), "Revision not found");
+        cpuinfo.write("Revision : 0002\n");
+        assert(resolver.memoryFlagFromCpuInfo(cpuinfo.path().c_str()) == 0x0CU);
+    }
+
+    for (const std::string malformed : {"", "not-hex", "a02082 trailing", "100000000"})
+    {
+        TemporaryCpuInfo cpuinfo;
+        cpuinfo.write("Revision : " + malformed + "\n");
+        mailbox_detail::RevisionResolver resolver;
+        expectRuntimeError(resolver, cpuinfo.path(), "invalid Revision");
+        cpuinfo.write("Revision : 0002\n");
+        assert(resolver.memoryFlagFromCpuInfo(cpuinfo.path().c_str()) == 0x0CU);
+    }
+
+    {
+        TemporaryCpuInfo cpuinfo;
+        cpuinfo.write("Revision : 0002\n");
+        mailbox_detail::RevisionResolver resolver;
+        assert(resolver.memoryFlagFromCpuInfo(cpuinfo.path().c_str()) == 0x0CU);
+        cpuinfo.write("Revision : 803000\n");
+        assert(resolver.memoryFlagFromCpuInfo(cpuinfo.path().c_str()) == 0x0CU);
+    }
+
+    for (const std::string revision : {"800000", "801000", "802000", "803000"})
+    {
+        TemporaryCpuInfo cpuinfo;
+        cpuinfo.write("Revision\t: " + revision + "\n");
+        mailbox_detail::RevisionResolver resolver;
+        const uint32_t expected = revision == "800000" ? 0x0CU : 0x04U;
+        assert(resolver.memoryFlagFromCpuInfo(cpuinfo.path().c_str()) == expected);
+    }
+
+    {
+        TemporaryCpuInfo cpuinfo;
+        cpuinfo.write("Revision : 804000\n");
+        mailbox_detail::RevisionResolver resolver;
+        expectRuntimeError(resolver, cpuinfo.path(), "unknown chipset");
+    }
+}

--- a/src/tests/ui_source_regression_test.cpp
+++ b/src/tests/ui_source_regression_test.cpp
@@ -1402,10 +1402,17 @@ int main()
     require(
         operation_view_source.find("id=\"gpio_frequency_correction_panel\"") != std::string::npos &&
             operation_view_source.find("id=\"gpio_frequency_correction_value\"") != std::string::npos &&
+            operation_view_source.find("GPIO correction provenance") != std::string::npos &&
+            operation_css_source.find("#gpio_frequency_correction_panel {\n    grid-column: 1 / -1;") != std::string::npos &&
             site_source.find("function renderGpioFrequencyCorrection(status)") != std::string::npos &&
-            site_source.find("frequencyEstimateQualification") != std::string::npos &&
-            site_source.find("effectiveGpioPpm") != std::string::npos,
-        "Operation view must show read-only GPIO provider qualification and effective-correction status");
+            site_source.find("gpioCorrectionCandidate") != std::string::npos &&
+            site_source.find("gpioCorrectionCommitted") != std::string::npos &&
+            site_source.find("Candidate refreshes do not alter a committed transmission.") != std::string::npos &&
+            websocket_source.find("reply[\"gpio_correction_candidate\"]") != std::string::npos &&
+            websocket_source.find("reply[\"gpio_correction_committed\"]") != std::string::npos &&
+            scheduling_source.find("j[\"gpio_correction_candidate\"]") != std::string::npos &&
+            scheduling_source.find("j[\"gpio_correction_committed\"]") != std::string::npos,
+        "Operation view must distinguish current candidate correction provenance from the frozen committed execution");
     require(
         config_view_source.find("config-runtime-item config-runtime-item--switch") == std::string::npos,
         "Runtime state body must no longer dedicate a body tile to the Transmit enabled control");

--- a/src/web_socket.cpp
+++ b/src/web_socket.cpp
@@ -645,6 +645,27 @@ void WebSocketServer::handleMessage(const std::string &raw_message)
             reply["gpio_frequency_residual_ppm"] = snapshot.gpio_frequency_residual_ppm;
             reply["effective_gpio_ppm"] = snapshot.effective_gpio_ppm;
             reply["frequency_estimate_age_seconds"] = snapshot.frequency_estimate_age_seconds;
+            const auto provenance_json = [](const auto &value)
+            {
+                return json{
+                    {"available", value.available}, {"active", value.active},
+                    {"processor_profile", value.processor_profile},
+                    {"selected_parent", value.selected_parent},
+                    {"nominal_rate_hz", value.nominal_rate_hz},
+                    {"intrinsic_ppm", value.intrinsic_ppm},
+                    {"selected_component_ppm", value.selected_component_ppm},
+                    {"conducted_residual_ppm", value.conducted_residual_ppm},
+                    {"final_ppm", value.final_ppm},
+                    {"correction_mode", value.correction_mode},
+                    {"provider_name", value.provider_name},
+                    {"provider_source_signature", value.provider_source_signature},
+                    {"provider_snapshot_time", value.provider_snapshot_time},
+                    {"execution_identity", value.execution_identity}};
+            };
+            reply["gpio_correction_candidate"] =
+                provenance_json(snapshot.gpio_correction_candidate);
+            reply["gpio_correction_committed"] =
+                provenance_json(snapshot.gpio_correction_committed);
             reply["rp1_package_expected"] = snapshot.rp1_package_expected;
             reply["rp1_route_requested"] = snapshot.rp1_route_requested;
             reply["rp1_route_persisted"] = snapshot.rp1_route_persisted;


### PR DESCRIPTION
## Summary

- define typed legacy GPIO processor/clock-parent models and carry correction provenance through scheduling and runtime planning
- apply the qualified legacy and RP1 GPIO correction baselines without conflating system-clock, intrinsic transmitter, or receiver corrections
- strengthen validation, UI status publication, and research documentation for the clock-model contract
- fail closed when the Mailbox component cannot read or parse the Raspberry Pi revision, with successful-only caching and focused regression coverage

Relates to #412.
Includes the current work for #429 and #430 without automatically closing those issues.

## Validation

- `make mailbox-memory-flag-test`
- `make legacy-gpio-clock-model-test`
- `make gpio-frequency-correction-test`
- focused scheduler, planner, UI-source, and fail-closed policy regression coverage added on the branch
- final staged diff whitespace/error check passed

The new focused Mailbox test and sanitizer run pass on macOS. The broader `make semantics-test` reaches and passes the new Mailbox and clock-model tests, then stops on this host because `gpiod.hpp` is unavailable. The standalone Mailbox build remains Linux-only because it requires `linux/ioctl.h`.

## Qualification boundary

This PR does not claim installation, service, GPIO timing, transmitter, RF-output, or end-to-end hardware qualification. Hardware-free tests qualify software contracts only.