### PR TITLE
Connect output-disabled runtime route workflow to application UI

### DIFF
--- a/WsprryPi-UI/data/index.js
+++ b/WsprryPi-UI/data/index.js
@@ -2354,6 +2354,9 @@ function clickTransmitPin() {
 }
 
 const RP1_ROUTE_STATES = Object.freeze({
+    runtime_inhibited: ["Output disabled", "Runtime route administration is available. Switching stops Wsprry Pi; verify completion with the operator client."],
+    runtime_recovery: ["Recovery required", "Inspect the controller error and ownership before explicit cleanup recovery."],
+    runtime_unknown: ["Completion unknown", "The application disconnected. Do not retry the switch. Run runtime_route_client.py query to inspect the result; transmission must remain inhibited."],
     checking: ["Checking", "Checking the external provider and active route…"],
     active: ["Active", "Requested and active routes match. No reboot is required."],
     reboot_required: ["Reboot required", "Review the requested route, then apply it and reboot or cancel the draft."],
@@ -2368,11 +2371,12 @@ const RP1_ROUTE_STATES = Object.freeze({
 class Rp1RouteUiController {
     constructor(endpoint, request = window.fetch.bind(window)) {
         this.endpoint=endpoint; this.request=request; this.persisted=""; this.active=""; this.outputValidated=false;
-        this.developmentCompatible=false; this.generation=0; this.inFlight=false;
+        this.completionUnknown=false; this.runtimeProfile=false; this.developmentCompatible=false; this.generation=0; this.inFlight=false;
     }
     visible() { return !document.getElementById("rp1-route-panel")?.hidden; }
     routeValue(value) { return value === "GPIO4" || value === "GPIO20" ? value : "Unavailable"; }
     setState(state, message="") {
+        if(state==="runtime_unknown") this.completionUnknown=true;
         const panel=document.querySelector(".rp1-route-panel");
         const badge=document.getElementById("rp1-route-state");
         const feedback=document.getElementById("rp1-route-feedback");
@@ -2385,13 +2389,15 @@ class Rp1RouteUiController {
     syncActions(state) {
         const draft=this.routeValue(`GPIO${getTxPin()}`);
         const changed=draft!=="Unavailable" && draft!==this.active;
-        const recovery=["staged","mismatch","rollback_required"].includes(state);
-        $("#rp1-route-apply").prop("disabled",this.inFlight || recovery || !changed);
+        const recovery=["staged","mismatch","rollback_required","runtime_recovery"].includes(state);
+        $("#rp1-route-apply").prop("disabled",this.inFlight || this.completionUnknown || recovery || state==="runtime_unknown" || !changed);
         $("#rp1-route-cancel").prop("disabled",this.inFlight || draft===this.persisted);
         $("#rp1-route-rollback").prop("hidden",!recovery).prop("disabled",this.inFlight);
     }
     render(data) {
+        this.completionUnknown=false;
         this.persisted=this.routeValue(data.persisted); this.active=this.routeValue(data.active);
+        this.runtimeProfile=data.profile==="runtime";
         this.developmentCompatible=data.compatible===true;
         this.generation=Number.isSafeInteger(data.generation) ? data.generation : 0;
         const requested=this.routeValue(data.requested || this.persisted);
@@ -2419,22 +2425,27 @@ class Rp1RouteUiController {
             : "No active lease or generation";
         $("#rp1-operation-lifecycle").text(lifecycle);
         $("#rp1-route-eligible").text("Unqualified");
-        $("#rp1-route-apply").text(this.developmentCompatible ? "Apply route and reboot" : "Check route");
+        $("#rp1-route-apply").text(this.runtimeProfile ? "Switch route (output disabled)" : (this.developmentCompatible ? "Apply route and reboot" : "Check route"));
+        $("#rp1-route-rollback").text(this.runtimeProfile ? "Recover to no route" : "Roll back");
         const reported=String(data.state || (requested===this.active ? "active" : "mismatch")).replaceAll("-","_");
         this.setState(reported,
             typeof data.message==="string" ? data.message : "");
     }
     select(route) {
         const requested=this.routeValue(route); $("#rp1-route-requested").text(requested);
-        this.setState(requested === this.active ? "active" : "reboot_required");
+        this.setState(this.runtimeProfile ? "runtime_inhibited" : (requested === this.active ? "active" : "reboot_required"));
     }
     async query() {
         this.inFlight=true; this.setState("checking");
         try { const response=await this.request(this.endpoint,{headers:{Accept:"application/json"}});
             if(!response.ok) throw new Error(); this.inFlight=false; this.render(await response.json());
-        } catch(_){this.inFlight=false;this.setState("unavailable");}
+        } catch(_){this.inFlight=false;this.setState(this.runtimeProfile ? "runtime_unknown" : "unavailable");}
     }
     async operate(operation) {
+        if(this.runtimeProfile && operation==="rollback") {
+            if(!window.confirm("Recover to no route? Wsprry Pi will stop and remain masked. Verify the result with the operator client before further administration.")) return;
+            operation="recover";
+        }
         const requested=this.routeValue(`GPIO${getTxPin()}`);
         this.inFlight=true; this.setState(operation==="rollback" ? "rollback" : "applying");
         try { const response=await this.request(this.endpoint,{method:"POST",
@@ -2442,7 +2453,7 @@ class Rp1RouteUiController {
                 body:JSON.stringify({operation, route:requested, generation:this.generation})});
             const data=await response.json(); this.inFlight=false;
             if(!response.ok && !data.state) throw new Error(); this.render(data);
-        } catch(_){this.inFlight=false;this.setState("unavailable");}
+        } catch(_){this.inFlight=false;this.setState(this.runtimeProfile ? "runtime_unknown" : "unavailable");}
     }
     async applyAndReboot() {
         const requested=this.routeValue(`GPIO${getTxPin()}`);
@@ -2452,18 +2463,21 @@ class Rp1RouteUiController {
                 headers:{"Content-Type":"application/json",Accept:"application/json"},
                 body:JSON.stringify({operation:"preflight",route:requested,generation:this.generation})});
             const preflight=await preflightResponse.json();
-            if(!preflightResponse.ok){this.inFlight=false;this.render(preflight);return;}
+            if(!preflightResponse.ok || preflight.ok!==true){this.inFlight=false;this.render(preflight);return;}
             this.generation=preflight.generation;
-            const confirmed=window.confirm(
+            const confirmed=window.confirm(this.runtimeProfile
+                ? `Switch to ${requested} with output disabled? Wsprry Pi will stop and remain masked. This browser may disconnect. Verify completion using runtime_route_client.py query. No reboot is requested.`
+                :
                 `Apply ${requested} and reboot? The package executor will stop only wsprrypi.service and soapyremote-server.service before changing its owned boot block.`
             );
             if(!confirmed){this.inFlight=false;this.render(preflight);return;}
+            if(this.runtimeProfile) { await this.operate("switch"); return; }
             this.setState("applying");
             const applyResponse=await this.request(this.endpoint,{method:"POST",
                 headers:{"Content-Type":"application/json",Accept:"application/json"},
                 body:JSON.stringify({operation:"apply-and-reboot",route:requested,generation:this.generation})});
             const applied=await applyResponse.json(); this.inFlight=false; this.render(applied);
-        } catch(_){this.inFlight=false;this.setState("unavailable");}
+        } catch(_){this.inFlight=false;this.setState(this.runtimeProfile ? "runtime_unknown" : "unavailable");}
     }
     cancel() {
         if(this.persisted!=="Unavailable") setTxPin(Number(this.persisted.slice(4)));

--- a/WsprryPi-UI/tests/rp1_route_ui_test.js
+++ b/WsprryPi-UI/tests/rp1_route_ui_test.js
@@ -24,3 +24,42 @@ assert.match(script,/wsprrypi\.service and soapyremote-server\.service/);
 assert.match(header,/'rp1RoutePath' => \$basePath \. '\/api\/rp1-gpclk-route'/);
 assert.match(styles,/@media \(max-width: 575\.98px\)[\s\S]*\.rp1-route-actions > \.btn/);
 console.log("rp1_route_ui_test passed");
+
+// Execute the real controller without a browser or external dependencies.
+const vm=require("node:vm");
+const nodes=new Map();
+function element(id){
+ if(!nodes.has(id)) nodes.set(id,{dataset:{},setAttribute(){},disabled:false,hidden:false,textContent:""});
+ return nodes.get(id);
+}
+let pin=20;
+const context={window:{fetch:async()=>{throw Error("no fixture")},confirm:()=>true},
+ document:{getElementById:element,querySelector:element},
+ getTxPin:()=>pin,setTxPin:value=>{pin=value},
+ $:selector=>({prop(name,value){element(selector.slice(1))[name]=value;return this},
+ text(value){element(selector.slice(1)).textContent=value;return this}})};
+vm.createContext(context);
+vm.runInContext(script.slice(script.indexOf("const RP1_ROUTE_STATES"),script.indexOf("function initializeRp1RouteUi"))+
+ ';globalThis.controller=new Rp1RouteUiController("/offline");',context);
+(async()=>{
+ const controller=context.controller;
+ controller.render({profile:"runtime",ok:true,state:"runtime_inhibited",persisted:"GPIO20",active:"GPIO4",compatible:true});
+ assert.equal(element("rp1-route-apply").textContent,"Switch route (output disabled)");
+ let confirmations=0,requests=[];
+ context.window.confirm=()=>{confirmations++;return true};
+ controller.request=async()=>({ok:true,json:async()=>({ok:false,profile:"runtime",state:"runtime_recovery"})});
+ await controller.applyAndReboot();
+ assert.equal(confirmations,0,"failed preflight cannot request confirmation");
+ controller.request=async(url,options)=>{requests.push(JSON.parse(options.body));throw Error("disconnected")};
+ await controller.operate("switch");
+ assert.equal(requests.length,1,"no automatic effect retries");
+ assert.equal(element("rp1-route-state").dataset.state,"runtime_unknown");
+ controller.select("GPIO20");
+ assert.equal(element("rp1-route-apply").disabled,true,"selection cannot clear unknown completion");
+ controller.render({profile:"runtime",ok:true,state:"runtime_recovery",persisted:"GPIO20",active:"GPIO4"});
+ assert.equal(element("rp1-route-rollback").hidden,false);
+ context.window.confirm=()=>false;
+ await controller.operate("rollback");
+ assert.equal(requests.length,1,"cancelled recovery has no effect");
+ console.log("runtime route UI behavior: PASS");
+})().catch(error=>{console.error(error);process.exitCode=1});

--- a/docs/runtime-route-workflow.md
+++ b/docs/runtime-route-workflow.md
@@ -1,0 +1,28 @@
+# Runtime route-manager application integration
+
+This companion implementation consumes the explicit schema-3
+`rp1-gpclk-route-manager-runtime-v1` profile from RP1-GPCLK-DKMS PR #7. The legacy
+packaged/source-development protocol remains separate. Unknown contracts fail
+closed; discovery of the runtime profile asserts the transmission inhibit and
+never satisfies startup or development output reconciliation.
+
+The existing route panel uses runtime preflight and an explicit **Switch route
+(output disabled)** confirmation. The application requires its full idle
+predicate, binds the request to the selected route and preflight generation/token,
+and persists the requested route separately from controller-reported active state.
+Recovery explicitly asks the controller to reach no route; it is not a rollback
+to a previous GPIO. Removal errors retain their kernel errno and overlay ID.
+
+The manager stops and persistently masks WsprryPi before route changes. The UI
+therefore warns that its HTTP connection may disappear. A disconnect means
+completion unknown, disables further switch attempts until fresh state is read,
+and directs the operator to `runtime_route_client.py query`. Subsequent operations
+while WsprryPi is stopped use that client. Nothing automatically unmasks, restarts,
+or authorizes output. A permanently available browser administration service is
+not provided by this change.
+
+Install/update/recovery belong to the module repository's separately reviewed
+runtime bundle workflow. This application commit does not install it, replace a
+running binary, change services, migrate a firmware route, reboot, or test GPIO.
+Coherent target deployment and clock-disabled GPIO4/GPIO20 switching still need
+separate authorization and proof. No product or RF qualification is claimed.

--- a/scripts/tests/backend_capability_reporting_test.sh
+++ b/scripts/tests/backend_capability_reporting_test.sh
@@ -34,7 +34,7 @@ if [[ -n "$omitted" ]]; then
         echo "invalid backend unexpectedly succeeded" >&2
         exit 1
     fi
-    grep -F "Invalid backend. Expected 'gpio', 'si5351', or 'simulated'." "$output_file" >/dev/null || {
+    grep -F "Invalid backend. Expected 'gpio', 'rp1-gpclk', 'si5351', or 'simulated'." "$output_file" >/dev/null || {
         cat "$output_file" >&2
         exit 1
     }

--- a/src/rp1_gpclk_route_service.cpp
+++ b/src/rp1_gpclk_route_service.cpp
@@ -18,6 +18,7 @@ namespace {
 #ifndef WSPRRYPI_ROUTE_SERVICE_TEST
 constexpr const char *kSocket = "/run/rp1-gpclk-dkms/route-manager.sock";
 #endif
+constexpr const char *kRuntimeContract = "rp1-gpclk-route-manager-runtime-v1";
 constexpr const char *kContract = "rp1-gpclk-route-manager-v1";
 #ifndef WSPRRYPI_ROUTE_SERVICE_TEST
 nlohmann::json socketRequest(const nlohmann::json &request) {
@@ -29,6 +30,12 @@ nlohmann::json socketRequest(const nlohmann::json &request) {
     ::close(fd);
     throw std::runtime_error(
         "Could not secure the RP1 GPCLK route-manager socket.");
+  }
+  const timeval timeout{30, 0};
+  if (::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) ||
+      ::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout))) {
+    ::close(fd);
+    throw std::runtime_error("Could not bound the route-manager connection.");
   }
   sockaddr_un address{};
   address.sun_family = AF_UNIX;
@@ -118,7 +125,8 @@ nlohmann::json Rp1GpclkRouteService::failure(const std::string &result,
                                              const std::string &message) const {
   return {{"ok", false},
           {"result", result},
-          {"state", "unavailable"},
+          {"state", runtime_profile_ ? "runtime_recovery" : "unavailable"},
+          {"profile", runtime_profile_ ? "runtime" : "legacy"},
           {"message", message},
           {"generation", generation_},
           {"requested", "Unavailable"},
@@ -140,7 +148,15 @@ nlohmann::json Rp1GpclkRouteService::failure(const std::string &result,
 nlohmann::json Rp1GpclkRouteService::request(const nlohmann::json &value) {
   try {
     const auto response = operations_.request(value);
-    if (!response.is_object() || response.value("schemaVersion", 0) != 1 ||
+    if (response.is_object() && response.value("schemaVersion", 0) == 3 &&
+        response.value("contract", std::string{}) == kRuntimeContract &&
+        response.contains("status") &&
+        (response.contains("state") || response.contains("error"))) {
+      runtime_profile_ = true;
+      operations_.set_transmission_inhibited(true, "Runtime route administration is output-disabled");
+      return response;
+    }
+    if (runtime_profile_ || !response.is_object() || response.value("schemaVersion", 0) != 1 ||
         response.value("contract", std::string{}) != kContract ||
         !response.contains("status") ||
         (response.contains("state") == response.contains("error")))
@@ -163,6 +179,41 @@ nlohmann::json Rp1GpclkRouteService::render(const nlohmann::json &response,
     return failure("route_manager_error", message);
   }
   const auto &state = response["state"];
+  if (runtime_profile_) {
+    auto result = failure("runtime_inhibited", "Runtime administration keeps transmission disabled. Switching stops and masks Wsprry Pi; use the operator client to verify completion.");
+    const bool valid = state.is_object() && state.value("profile", std::string{}) == "runtime" &&
+        state.contains("outputEnabled") && state["outputEnabled"] == false &&
+        state.contains("qualification") && state["qualification"] == false &&
+        state.contains("controller") && state["controller"].is_object();
+    result["profile"] = "runtime";
+    result["contractIdentity"] = kRuntimeContract;
+    result["ok"] = valid && status != "error";
+    result["compatible"] = valid;
+    result["state"] = status == "error" ? "runtime_recovery" : "runtime_inhibited";
+    result["active"] = routeForGpio(gpioForRoute(field(state, "activeRoute")));
+    result["requested"] = requested.empty() ? routeForGpio(operations_.persisted_gpio()) : requested;
+    result["liveOutput"] = "Disabled";
+    result["bootOwnership"] = "runtime controller";
+    result["journal"] = state.contains("pendingTransaction") && state["pendingTransaction"].is_object()
+        ? field(state["pendingTransaction"], "phase") : "none";
+    result["preflightValidated"] = valid && status == "ok" && field(state, "preflightToken").size() == 64;
+    result["controller"] = state.value("controller", nlohmann::json::object());
+    if (valid) {
+      const auto phase = result["journal"].get<std::string>();
+      if ((state["controller"].value("flags", 0) & 1) ||
+          (phase != "none" && phase != "complete-inhibited" && phase != "recovered-inhibited"))
+        result["state"] = "runtime_recovery";
+    }
+    if (response.contains("error")) {
+      result["message"] = field(response["error"], "message");
+      result["error"] = response["error"];
+      if (response["error"].contains("kernelError") && response["error"].contains("overlayId"))
+        result["message"] = field(response["error"], "message") + " Kernel errno: " +
+            response["error"]["kernelError"].dump() + "; retained overlay ID: " +
+            response["error"]["overlayId"].dump() + ". Transmission remains inhibited.";
+    }
+    return result;
+  }
   const std::string configured = routeForGpio(
                         gpioForRoute(field(state, "configuredRoute"))),
                     active =
@@ -233,6 +284,46 @@ nlohmann::json Rp1GpclkRouteService::operate(const std::string &operation,
   const std::string executor_route = gpio == 4    ? "gpio4"
                                      : gpio == 20 ? "gpio20"
                                                   : "";
+  if (runtime_profile_) {
+    if (!idle())
+      return failure("not_idle", "Runtime administration requires the complete application lifecycle to be idle.");
+    if (operation == "preflight") {
+      runtime_token_.clear();
+      preflight_route_.clear();
+      if (executor_route.empty())
+        return failure("invalid_route", "Route must be GPIO4 or GPIO20.");
+      auto raw = request({{"schemaVersion", 3}, {"operation", "preflight"}, {"route", executor_route}});
+      auto result = render(raw, route);
+      if (result.value("ok", false) && result.value("preflightValidated", false)) {
+        runtime_token_ = field(raw["state"], "preflightToken");
+        preflight_route_ = executor_route;
+        result["generation"] = ++generation_;
+      } else {
+        result["ok"] = false;
+      }
+      return result;
+    }
+    if (operation != "switch" && operation != "recover")
+      return failure("invalid_operation", "Runtime profile requires explicit switch or recover; reboot operations are not translated.");
+    if (operation == "switch" && (generation == 0 || generation != generation_ ||
+        runtime_token_.empty() || executor_route != preflight_route_))
+      return failure("generation_mismatch", "Repeat runtime preflight before switching.");
+    operations_.set_transmission_inhibited(true, "Runtime route administration in progress");
+    nlohmann::json value = {{"schemaVersion", 3}, {"operation", operation}, {"execute", true},
+        {"actor", "wsprrypi.service"}, {"requestId", requestId(operation.c_str(), ++generation_)}};
+    if (operation == "switch") {
+      value["route"] = executor_route;
+      value["preflightToken"] = runtime_token_;
+      // The token binds the ID across application restarts as well as preflights.
+      value["requestId"] = "wsprrypi-" + runtime_token_.substr(0, 48);
+      std::string error;
+      if (!operations_.persist_gpio || !operations_.persist_gpio(gpio, &error))
+        return failure("persistence_failed", error);
+    }
+    runtime_token_.clear();
+    preflight_route_.clear();
+    return render(request(value), route);
+  }
   if (operation == "preflight") {
     if (!idle())
       return failure("not_idle",

--- a/src/rp1_gpclk_route_service.hpp
+++ b/src/rp1_gpclk_route_service.hpp
@@ -36,6 +36,8 @@ private:
   std::mutex mutex_;
   std::uint64_t generation_{0};
   std::string preflight_route_;
+  bool runtime_profile_{false};
+  std::string runtime_token_;
   bool startup_failure_latched_{false};
 };
 Rp1GpclkRouteService &productionRp1GpclkRouteService();

--- a/src/tests/rp1_gpclk_route_service_test.cpp
+++ b/src/tests/rp1_gpclk_route_service_test.cpp
@@ -384,5 +384,34 @@ int main() {
           {"state", state()}};
   assert(service.query().at("result") == "contract_mismatch");
 
+  next = {{"schemaVersion", 3}, {"contract", "rp1-gpclk-route-manager-runtime-v1"},
+          {"status", "ok"}, {"state", {{"profile", "runtime"}, {"activeRoute", "gpio4"},
+          {"outputEnabled", false}, {"qualification", false}, {"controller", {{"id", 9}}},
+          {"preflightToken", std::string(64, 'a')}}}};
+  assert(service.query().at("profile") == "runtime");
+  assert(inhibited);
+  auto runtime_preflight = service.operate("preflight", "GPIO20", 0);
+  assert(runtime_preflight.at("ok") == true);
+  const auto runtime_generation = runtime_preflight.at("generation").get<std::uint64_t>();
+  assert(requests.back().at("schemaVersion") == 3);
+  assert(service.operate("switch", "GPIO20", runtime_generation + 1).at("ok") == false);
+  assert(service.operate("apply-and-reboot", "GPIO20", runtime_generation).at("ok") == false);
+  next["status"] = "complete-inhibited";
+  assert(service.operate("switch", "GPIO20", runtime_generation).at("ok") == true);
+  assert(requests.back().at("operation") == "switch");
+  assert(requests.back().at("preflightToken") == std::string(64, 'a'));
+  assert(inhibited);
+  assert(service.operate("switch", "GPIO20", runtime_generation).at("ok") == false);
+  next["status"] = "error";
+  next["error"] = {{"message", "overlay removal failed"}, {"kernelError", -16}, {"overlayId", 9}};
+  const auto runtime_failure = service.operate("recover", "GPIO20", 0);
+  assert(runtime_failure.at("ok") == false);
+  assert(runtime_failure.at("error").at("kernelError") == -16);
+  assert(runtime_failure.at("error").at("overlayId") == 9);
+  assert(inhibited);
+  next = response("query", "ok", state());
+  assert(service.query().at("result") == "contract_mismatch");
+  assert(inhibited);
+
   std::cout << "rp1_gpclk_route_service_test: PASS\n";
 }

--- a/src/tests/startup_quiesce_parent_test.cpp
+++ b/src/tests/startup_quiesce_parent_test.cpp
@@ -23,6 +23,10 @@ ArgParserConfig cfg_for(EnableOnBootBehavior policy)
 {
     init_default_config();
     auto cfg = config;
+    // Exercise the non-WSPR launch gate with an explicit hardware-free profile.
+    cfg.mode = ModeType::QRSS;
+    cfg.transmit_backend = TransmitBackendKind::SIMULATED;
+    cfg.schedule_repeat_minutes = 0;
     cfg.use_ini = true;
     cfg.transmit = true;
     cfg.enable_on_boot = policy;


### PR DESCRIPTION
## Purpose
Connect the application route workflow to the explicit output-disabled runtime controller profile introduced by [RP1-GPCLK-DKMS PR #7](https://github.com/WsprryPi/RP1-GPCLK-DKMS/pull/7), now merged. The existing packaged and source-development protocols remain separate.

## Changes
- Discover schema 3 and its exact runtime contract, fail closed on unknown profiles, and retain transmission inhibition.
- Require application idle state, current preflight generation and manager token for switching; keep requested and active GPIO separate.
- Expose explicit switch and recover-to-no-route controls while preserving kernel errno and overlay ownership details.
- Warn that administration stops and masks WsprryPi, may disconnect HTTP, and requires CLI administration afterward. Unknown completion prevents automatic retries until fresh state is read.

## Validation
- Offline C++ route-service and runtime-wiring tests passed again before merge in a network-disabled Debian ARM64 container.
- JavaScript route UI static and behavioral tests passed again before merge.
- Earlier implementation review included production syntax checking, desktop/mobile rendering, and iterative adversarial assessment.
- Changed-file whitespace check passed.
- Initial CI exposed a pre-existing backend diagnostic assertion that omitted `rp1-gpclk`; commit 73019e0 updates that exact expected text without weakening rejection checks or changing runtime behavior. A second existing fixture called the non-WSPR launch helper with the WSPR default; commit 962bd77 selects simulated QRSS explicitly and retains the no-request and inhibition assertions. Its hardware-disabled container test passed. All four GitHub CI jobs passed on head 962bd77 (run 33401850816): macOS simulated profile, strict I2C profile, six-profile GCC 13 release build, and the complete non-hardware validation suite.

## Boundaries
This PR does not install or release a runtime bundle, move a release pin, deploy the application to wspr5, unmask services, enable clocks, or authorize transmission. Module-repository evidence records clock-disabled GPIO4/GPIO20 target switching; it does not establish deployed application UI behavior, crash/fault-injection coverage, electrical silence, or product/RF qualification. Always-available browser administration and automatic post-reboot route restoration remain outside this scope.
