### PR TITLE
Integrate runtime RP1 reconciliation and preserve TONE failures

### DIFF
--- a/docs/runtime-route-workflow.md
+++ b/docs/runtime-route-workflow.md
@@ -34,3 +34,16 @@ The manager can explicitly release its application mask with `resume gpio20
 after that request returns. The existing ABI-v4 lease supports authorized output
 with the module loaded at `live_output=0`; no globally enabled load is needed.
 Route changes still stop and mask the application.
+
+Bounded-tone start acknowledgements are asynchronous. A response includes an
+RP1 operation record only when it belongs to that request; the terminal record
+retains provider failure reasons and cleanup failures. A worker exception is
+reported without terminating the application process.
+
+The 2026-08-31 wspr5 integration test exercised GPIO20 at a requested
+14.097100 MHz for ten seconds, including repeated execution and cleanup without
+a reboot. Exact source/build identities, failed attempts and successful outcomes
+are retained in RP1-GPCLK-DKMS under `docs/evidence/runtime-tone-20260831/`.
+This is not analyzer frequency or product qualification. The test used a
+temporary configuration and transient loopback-only service; the normal INI,
+served UI and masked service were not replaced as part of that test.

--- a/docs/runtime-route-workflow.md
+++ b/docs/runtime-route-workflow.md
@@ -3,8 +3,10 @@
 This companion implementation consumes the explicit schema-3
 `rp1-gpclk-route-manager-runtime-v1` profile from RP1-GPCLK-DKMS PR #7. The legacy
 packaged/source-development protocol remains separate. Unknown contracts fail
-closed; discovery of the runtime profile asserts the transmission inhibit and
-never satisfies startup or development output reconciliation.
+closed; discovery of the runtime profile asserts the transmission inhibit. Explicit
+`idle` and `reconcile-output` requests now establish runtime route readiness for
+startup and the existing operation-scoped development authorization path. Neither
+query authorizes output.
 
 The existing route panel uses runtime preflight and an explicit **Switch route
 (output disabled)** confirmation. The application requires its full idle
@@ -26,3 +28,9 @@ runtime bundle workflow. This application commit does not install it, replace a
 running binary, change services, migrate a firmware route, reboot, or test GPIO.
 Coherent target deployment and clock-disabled GPIO4/GPIO20 switching still need
 separate authorization and proof. No product or RF qualification is claimed.
+
+The manager can explicitly release its application mask with `resume gpio20
+--execute` after validating the idle runtime route. Start the application only
+after that request returns. The existing ABI-v4 lease supports authorized output
+with the module loaded at `live_output=0`; no globally enabled load is needed.
+Route changes still stop and mask the application.

--- a/src/WSPR-Transmitter/src/rp1_gpclk_transmit_backend.cpp
+++ b/src/WSPR-Transmitter/src/rp1_gpclk_transmit_backend.cpp
@@ -455,10 +455,7 @@ wsprrypi::ExecutionResult WsprRp1GpclkBackend::execute(
 
         {
             std::lock_guard<std::mutex> lock(backend_mutex_);
-            const auto event_state = configured_->finite_events
-                ? provider_->eventState(backend_->generation())
-                : wsprrypi::Rp1GpclkProviderEventState{
-                      provider_->state(backend_->generation()), 0, 0};
+            const auto event_state = provider_->eventState(backend_->generation());
             const auto state = event_state.completion;
             if (configured_->finite_events &&
                 event_state.current_event < plan.events.size())
@@ -466,24 +463,26 @@ wsprrypi::ExecutionResult WsprRp1GpclkBackend::execute(
             if (state == wsprrypi::Rp1GpclkCompletionState::complete ||
                 state == wsprrypi::Rp1GpclkCompletionState::failed)
             {
-                if (!backend_->cleanup(error))
+                auto record = wsprrypi::rp1GpclkOperationRecordSnapshot();
+                const bool cleaned = backend_->cleanup(error);
+                record.terminal_reason = event_state.terminal_reason;
+                record.state = !cleaned ? "cleanup-fault" :
+                    state == wsprrypi::Rp1GpclkCompletionState::complete
+                        ? "complete" : "failed";
+                record.cleanup_attempted = true;
+                record.cleanup_complete = cleaned;
+                record.endpoint_closed = cleaned;
+                if (cleaned) record.lease = 0;
+                record.finished_monotonic_ns = static_cast<std::uint64_t>(
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        std::chrono::steady_clock::now().time_since_epoch()).count());
+                update_record(record);
+                if (!cleaned)
                 {
                     result.error = error;
                     result.faulted = true;
                     return result;
                 }
-                auto record = wsprrypi::rp1GpclkOperationRecordSnapshot();
-                record.terminal_reason = event_state.terminal_reason;
-                record.state = state == wsprrypi::Rp1GpclkCompletionState::complete
-                    ? "complete" : "failed";
-                record.cleanup_attempted = true;
-                record.cleanup_complete = true;
-                record.endpoint_closed = true;
-                record.lease = 0;
-                record.finished_monotonic_ns = static_cast<std::uint64_t>(
-                    std::chrono::duration_cast<std::chrono::nanoseconds>(
-                        std::chrono::steady_clock::now().time_since_epoch()).count());
-                update_record(record);
                 if (state == wsprrypi::Rp1GpclkCompletionState::failed)
                 {
                     result.error = "RP1 GPCLK provider reported frame failure.";

--- a/src/WSPR-Transmitter/src/rp1_gpclk_transmit_backend_test.cpp
+++ b/src/WSPR-Transmitter/src/rp1_gpclk_transmit_backend_test.cpp
@@ -70,7 +70,8 @@ public:
     }
     bool requestFiniteStop(std::uint64_t, std::string&) override { stopped=true; return true; }
     wsprrypi::Rp1GpclkCompletionState state(std::uint64_t) const noexcept override { return state_value; }
-    wsprrypi::Rp1GpclkProviderEventState eventState(std::uint64_t) const noexcept override { return {state_value,current_event,0}; }
+    wsprrypi::Rp1GpclkProviderEventState eventState(std::uint64_t) const noexcept override { return {state_value,current_event,terminal_reason}; }
+    std::uint32_t terminal_reason{};
     bool release(std::string&) noexcept override { released=true; return true; }
     std::uint64_t leaseId() const noexcept override { return 41; }
     std::uint32_t acquired_route{}; std::uint64_t required_capabilities{};
@@ -366,10 +367,13 @@ int main()
             expected_tone.tones[0].upper_divider_word,
         "TONE must plan divider words from the 200 MHz compatibility parent");
     auto finite_provider=std::make_unique<Provider>(); Provider* finite_observed=finite_provider.get();
+    finite_observed->terminal_reason = RP1_GPCLK_REASON_COMPLETE;
     WsprRp1GpclkBackend finite_backend(owner,std::move(finite_provider));
     auto explicit_tone=tonePlan(true);
     expect(finite_backend.configure(explicit_tone,developmentInputs()).ok && finite_backend.execute(explicit_tone).ok,
         "explicit-duration TONE must use finite ABI v2 operation");
+    expect(wsprrypi::rp1GpclkOperationRecordSnapshot().terminal_reason == RP1_GPCLK_REASON_COMPLETE,
+        "TONE must preserve the provider terminal reason in its operation record");
     expect(finite_observed->tone_program.operation==RP1_GPCLK_TONE_OPERATION_FINITE &&
         finite_observed->tone_program.duration_ns==1000000000ULL &&
         (finite_observed->required_capabilities & RP1_GPCLK_CAP_TONE_FINITE)!=0,

--- a/src/WSPR-Transmitter/src/wspr_transmit.cpp
+++ b/src/WSPR-Transmitter/src/wspr_transmit.cpp
@@ -2085,7 +2085,7 @@ inline double WsprTransmitter::convert_mw_dbm(double mw)
     return 10.0 * std::log10(mw);
 }
 
-void WsprTransmitter::thread_entry()
+void WsprTransmitter::thread_entry() try
 {
     const int ncpu = cpu_count();
 
@@ -2136,6 +2136,28 @@ void WsprTransmitter::thread_entry()
             std::string("WsprTransmitter::thread_entry(): Unexpected error: ") + e.what());
     }
     transmit();
+}
+catch (const std::exception &error)
+{
+    state_.store(State::FAILED, std::memory_order_release);
+    const auto cleanup = cleanupTransmissionBackend();
+    try {
+        std::string message = error.what();
+        if (!cleanup.ok) message += "; cleanup failed: " + cleanup.error;
+        fire_transmit_cb(TransmissionCallbackEvent::FAILED, LogLevel::ERROR,
+                         message, 0.0);
+    } catch (...) {
+        // A throwing notification must not escape a std::thread boundary.
+    }
+}
+catch (...)
+{
+    state_.store(State::FAILED, std::memory_order_release);
+    (void)cleanupTransmissionBackend();
+    try {
+        fire_transmit_cb(TransmissionCallbackEvent::FAILED, LogLevel::ERROR,
+                         "Unknown transmission worker failure.", 0.0);
+    } catch (...) {}
 }
 
 void WsprTransmitter::set_thread_priority()

--- a/src/rp1_gpclk_route_service.cpp
+++ b/src/rp1_gpclk_route_service.cpp
@@ -422,6 +422,47 @@ nlohmann::json Rp1GpclkRouteService::reconcileStartup() {
       !reconciled, reconciled ? "" : "RP1 GPCLK reconciliation is incomplete");
   return rendered;
 }
+nlohmann::json Rp1GpclkRouteService::reconcileRuntime(
+    const std::string &route, bool development) {
+  const int gpio = gpioForRoute(route);
+  if (!gpio || gpio != operations_.persisted_gpio())
+    return failure("runtime_route_mismatch", "Requested and saved runtime route differ.");
+  const auto raw = request({{"schemaVersion",3},
+      {"operation",development ? "reconcile-output" : "idle"},
+      {"route",gpio == 4 ? "gpio4" : "gpio20"}});
+  const auto state = raw.value("state", nlohmann::json::object());
+  const auto output = state.value("outputLifecycle", nlohmann::json::object());
+  const auto controller = output.value("controller", nlohmann::json::object());
+  const bool valid = raw.value("status", std::string{}) == "ok" &&
+      output.value("ready", false) && !output.value("executionAuthorized", true) &&
+      output.value("route", std::string{}) == (gpio == 4 ? "gpio4" : "gpio20") &&
+      output.value("bootId", std::string{}) == state.value("bootId", std::string{}) &&
+      !output.value("bootId", std::string{}).empty() &&
+      output.value("bindingSha256", std::string{}) == state.value("bindingSha256", std::string{}) &&
+      output.value("bindingSha256", std::string{}).size() == 64 &&
+      controller == state.value("controller", nlohmann::json::object()) &&
+      controller.value("route", 0) == (gpio == 4 ? 1 : 2) &&
+      controller.value("flags", 0) == 6 && controller.value("error", -1) == 0 &&
+      controller.value("session", 0ULL) != 0 && controller.value("generation", 0ULL) != 0;
+  if (!valid) {
+    const auto error = raw.value("error", nlohmann::json::object());
+    return failure("runtime_reconciliation_failed", error.value("message",
+        std::string("Runtime route reconciliation failed; output remains inhibited.")));
+  }
+  auto result = failure("runtime_reconciled", "Runtime route reconciled; existing operation authorization is still required.");
+  result.update({{"ok",true},{"reconciled",true},{"compatible",true},
+      {"requested",route},{"persisted",route},{"configured",route},{"active",route},
+      {"journal","none"},{"bootOwnership","runtime"},{"endpointOwned",true},
+      {"endpointOpen",false},{"liveOutput","disabled"},
+      {"generation",++generation_},
+      {"controllerGeneration",controller["generation"]},
+      {"policyDomain",development ? "external-provider" : "startup-idle"},
+      {"executionAuthorized",false},{"qualification",false}});
+  operations_.set_transmission_inhibited(!development,
+      development ? "" : "Runtime idle startup awaits an operation authorization");
+  return result;
+}
+
 nlohmann::json Rp1GpclkRouteService::reconcileIdleStartup(
     const std::string &route) {
   std::lock_guard<std::mutex> guard(mutex_);
@@ -438,8 +479,13 @@ nlohmann::json Rp1GpclkRouteService::reconcileIdleStartup(
                    "RP1 GPCLK idle startup requires GPIO4 or GPIO20.");
   }
 
-  auto rendered = render(request({{"schemaVersion", 1},
-                                  {"operation", "query"}}), expected);
+  auto discovered = request({{"schemaVersion", 1}, {"operation", "query"}});
+  if (runtime_profile_) {
+    auto result = reconcileRuntime(expected, false);
+    startup_failure_latched_ = !result.value("ok", false);
+    return result;
+  }
+  auto rendered = render(discovered, expected);
   const auto exact_route_state = [&expected](const nlohmann::json &value) {
     return value.value("ok", false) &&
            value.value("reconciled", false) &&
@@ -499,8 +545,9 @@ nlohmann::json Rp1GpclkRouteService::reconcileDevelopmentStartup(
   }
 
   ++generation_;
-  auto rendered = render(request({{"schemaVersion", 1},
-                                  {"operation", "query"}}), expected);
+  auto discovered = request({{"schemaVersion", 1}, {"operation", "query"}});
+  if (runtime_profile_) return reconcileRuntime(expected, true);
+  auto rendered = render(discovered, expected);
   const bool reconciled = rendered.value("ok", false) &&
                           rendered.value("reconciled", false) &&
                           rendered.value("requested", std::string{}) == expected &&

--- a/src/rp1_gpclk_route_service.hpp
+++ b/src/rp1_gpclk_route_service.hpp
@@ -28,6 +28,7 @@ private:
   nlohmann::json render(const nlohmann::json &,
                         const std::string &requested = {});
   nlohmann::json failure(const std::string &, const std::string &) const;
+  nlohmann::json reconcileRuntime(const std::string &, bool);
   bool idle() const;
   static std::string routeForGpio(int);
   static int gpioForRoute(const std::string &);

--- a/src/test_tone_response.cpp
+++ b/src/test_tone_response.cpp
@@ -1,2 +1,14 @@
 #include "test_tone_response.hpp"
+void attach_rp1_operation_record(nlohmann::json &reply, const nlohmann::json &record,
+                                 bool terminal)
+{
+    // Startup is asynchronous: never attach the preceding operation's result.
+    if (record.value("operationId", "") != reply.value("request_id", "")) return;
+    reply["rp1_operation_record"] = record;
+    if (terminal && record.value("state", "") != "complete")
+    {
+        reply["status"] = "error";
+        reply["message"] = "RP1 operation failed; inspect rp1_operation_record.";
+    }
+}
 nlohmann::json build_test_tone_response(const ParsedTestToneRequest&r,const TestToneStartResult&s){nlohmann::json j={{"command","tone_start"},{"started",s.started},{"already_active",s.already_active},{"blocked_by_active_transmission",s.blocked_by_active_transmission},{"blocked_by_enabled_transmission",s.blocked_by_enabled_transmission},{"message",s.message},{"status",s.started?"ok":"error"},{"tone_start",s.started?"ok":"rejected"}};if(!s.started)return j;if(r.source==TestToneRequestSource::WsprBand){j["frequency_source"]="wspr_band";j["band"]=s.band;j["dial_frequency_hz"]=s.dial_frequency_hz;j["audio_offset_hz"]=s.audio_offset_hz;j["actual_rf_frequency_hz"]=s.actual_rf_frequency_hz;j["resolution_source"]=wspr_band_resolution_source_name(s.resolution_source);j["preset"]=s.preset?nlohmann::json(*s.preset):nlohmann::json(nullptr);}else if(r.source==TestToneRequestSource::CustomRf){j["frequency_source"]="custom_rf";j["band"]=s.band;j["actual_rf_frequency_hz"]=s.actual_rf_frequency_hz;j["resolution_source"]="custom_rf";}if(r.source==TestToneRequestSource::WsprBand||r.source==TestToneRequestSource::CustomRf){j["selector_gpio_enabled"]=s.selector_gpio_enabled;j["selector_gpio"]=s.selector_gpio;j["selector_gpio_active_high"]=s.selector_gpio_enabled?s.selector_gpio_active_high:false;}return j;}

--- a/src/test_tone_response.hpp
+++ b/src/test_tone_response.hpp
@@ -3,3 +3,4 @@
 #include "test_tone_request.hpp"
 #include "json.hpp"
 nlohmann::json build_test_tone_response(const ParsedTestToneRequest&, const TestToneStartResult&);
+void attach_rp1_operation_record(nlohmann::json&, const nlohmann::json&, bool terminal);

--- a/src/tests/cleanup_lifecycle_test.cpp
+++ b/src/tests/cleanup_lifecycle_test.cpp
@@ -150,6 +150,24 @@ void test_cancellation_cleanup_failure_prevents_false_cancel_success()
            "cancellation cleanup failure must remain a failed lifecycle");
 }
 
+void test_async_execution_exception_is_reported_without_process_abort()
+{
+    WsprTransmitter transmitter;
+    WsprTransmitter::SimulatedRuntimeConfig config;
+    config.fail_event = 0;
+    transmitter.selectBackend(wsprrypi::BackendKind::SIMULATED, {}, config);
+    transmitter.configureExecution(qrss_request(), legacy_request());
+    transmitter.startAsync();
+    for (int i = 0; i < 1000 &&
+         transmitter.getState() != WsprTransmitter::State::FAILED; ++i)
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    expect(transmitter.getState() == WsprTransmitter::State::FAILED,
+           "worker exception must become FAILED without terminating the process");
+    transmitter.stopAndJoin();
+    expect(transmitter.lastCleanupResult().ok,
+           "worker exception must complete backend cleanup");
+}
+
 void test_startup_quiesce_failure_propagates_without_arming_cleanup()
 {
     WsprTransmitter transmitter;
@@ -175,6 +193,7 @@ void test_startup_quiesce_failure_propagates_without_arming_cleanup()
 int main()
 try
 {
+    test_async_execution_exception_is_reported_without_process_abort();
     test_explicit_cleanup_and_stop_failure();
     test_backend_replacement_failure();
     test_configuration_and_cleanup_failure_preserve_both_errors();

--- a/src/tests/rp1_gpclk_route_service_test.cpp
+++ b/src/tests/rp1_gpclk_route_service_test.cpp
@@ -413,5 +413,39 @@ int main() {
   assert(service.query().at("result") == "contract_mismatch");
   assert(inhibited);
 
+  // Runtime reconciliation uses real current-route evidence, not a boot overlay.
+  nlohmann::json ctl = {{"id",1},{"route",2},{"flags",6},{"error",0},
+                        {"session",1234},{"generation",7}};
+  nlohmann::json lifecycle = {{"ready",true},{"executionAuthorized",false},
+      {"route","gpio20"},{"controller",ctl},{"bootId","current-boot"},
+      {"bindingSha256",std::string(64,'a')}};
+  auto runtime = nlohmann::json{{"schemaVersion",3},
+      {"contract","rp1-gpclk-route-manager-runtime-v1"},{"status","ok"},
+      {"state",{{"profile","runtime"},{"outputEnabled",false},{"qualification",false},
+          {"controller",ctl},{"bootId","current-boot"},{"bindingSha256",std::string(64,'a')},
+          {"outputLifecycle",lifecycle}}}};
+  bool runtime_inhibited = true;
+  std::vector<nlohmann::json> runtime_requests;
+  wsprrypi::Rp1GpclkRouteService runtime_service({
+      [&](const nlohmann::json &value) { runtime_requests.push_back(value); return runtime; },
+      idle, [] {return 20;}, [](int,std::string*) {return false;},
+      [&](bool value,const std::string&) {runtime_inhibited=value;}});
+  auto idle_runtime = runtime_service.reconcileIdleStartup("GPIO20");
+  assert(idle_runtime.at("ok") == true && runtime_inhibited);
+  assert(idle_runtime.at("executionAuthorized") == false);
+  assert(runtime_requests.back().at("operation") == "idle");
+  auto development_runtime = runtime_service.reconcileDevelopmentStartup("GPIO20");
+  assert(development_runtime.at("ok") == true && !runtime_inhibited);
+  assert(development_runtime.at("executionAuthorized") == false);
+  assert(runtime_requests.back().at("operation") == "reconcile-output");
+  assert(development_runtime.at("generation") != idle_runtime.at("generation"));
+  runtime["state"]["outputLifecycle"]["controller"]["route"] = 1;
+  assert(runtime_service.reconcileDevelopmentStartup("GPIO20").at("ok") == false);
+  assert(runtime_inhibited);
+  runtime["state"]["outputLifecycle"] = lifecycle;
+  runtime["state"]["outputLifecycle"]["executionAuthorized"] = true;
+  assert(runtime_service.reconcileDevelopmentStartup("GPIO20").at("ok") == false);
+  assert(runtime_inhibited);
+
   std::cout << "rp1_gpclk_route_service_test: PASS\n";
 }

--- a/src/tests/test_tone_response_test.cpp
+++ b/src/tests/test_tone_response_test.cpp
@@ -53,6 +53,16 @@ static void require_no_semantic_details(
 
 int main()
 {
+    nlohmann::json reply = {{"request_id", "current"}, {"status", "ok"}};
+    attach_rp1_operation_record(reply, {{"operationId", "previous"}, {"state", "complete"}}, false);
+    require(!reply.contains("rp1_operation_record"), "must not attach a stale operation record");
+    attach_rp1_operation_record(reply, {{"operationId", "current"}, {"state", "complete"}}, true);
+    require(reply["status"] == "ok", "completed current operation remains successful");
+    for (const char *state : {"failed", "cleanup-fault", "submit-failed", "acquire-failed", "draining"}) {
+        reply["status"] = "ok";
+        attach_rp1_operation_record(reply, {{"operationId", "current"}, {"state", state}}, true);
+        require(reply["status"] == "error", "non-complete terminal operation must report error");
+    }
     TestToneStartResult result;
     result.started = true;
     result.message = "started";

--- a/src/web_socket.cpp
+++ b/src/web_socket.cpp
@@ -784,7 +784,7 @@ void WebSocketServer::handleMessage(const std::string &raw_message)
                         reply["request_id"] = parsed.request->request_id;
                         reply["duration_ms"] = parsed.request->duration_ms;
 #if WSPRRYPI_BACKEND_RP1_GPCLK
-                        reply["rp1_operation_record"] = rp1_operation_record_json();
+                        attach_rp1_operation_record(reply, rp1_operation_record_json(), false);
 #endif
                         if (start_result.started)
                         {
@@ -835,16 +835,8 @@ void WebSocketServer::handleMessage(const std::string &raw_message)
                                                 ? "ok" : "error"},
                                             {"message", stopped.message}};
 #if WSPRRYPI_BACKEND_RP1_GPCLK
-                                        terminal["rp1_operation_record"] =
-                                            rp1_operation_record_json();
-                                        const auto &record = terminal["rp1_operation_record"];
-                                        if (record["state"] == "failed" ||
-                                            record["state"] == "cleanup-fault")
-                                        {
-                                            terminal["status"] = "error";
-                                            terminal["message"] =
-                                                "RP1 operation failed; inspect rp1_operation_record.";
-                                        }
+                                        attach_rp1_operation_record(
+                                            terminal, rp1_operation_record_json(), true);
 #endif
                                         if (running_)
                                             sendAllClients(terminal.dump());

--- a/src/web_socket.cpp
+++ b/src/web_socket.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "web_socket.hpp"
+#include "backend_capabilities.hpp"
 #if WSPRRYPI_BACKEND_RP1_GPCLK
 #include "WSPR-Transmitter/src/rp1_gpclk_transmit_backend.hpp"
 #endif

--- a/src/web_socket.cpp
+++ b/src/web_socket.cpp
@@ -837,6 +837,14 @@ void WebSocketServer::handleMessage(const std::string &raw_message)
 #if WSPRRYPI_BACKEND_RP1_GPCLK
                                         terminal["rp1_operation_record"] =
                                             rp1_operation_record_json();
+                                        const auto &record = terminal["rp1_operation_record"];
+                                        if (record["state"] == "failed" ||
+                                            record["state"] == "cleanup-fault")
+                                        {
+                                            terminal["status"] = "error";
+                                            terminal["message"] =
+                                                "RP1 operation failed; inspect rp1_operation_record.";
+                                        }
 #endif
                                         if (running_)
                                             sendAllClients(terminal.dump());


### PR DESCRIPTION
The installed application could discover the schema-3 RP1 runtime manager but could not reconcile its route for startup and existing development output. This connects those paths while preserving the established ABI-v4 operation lease and application authorization.

Actual target tests also exposed uncaught transmission-worker failures, omitted RP1 operation records, lost terminal reasons and misleading cleanup results. The worker now reports errors without aborting the process. Bounded responses preserve failures and include only the current request's operation record.

Validation:

- Focused route-service, runtime-wiring, backend, cleanup-lifecycle and response regression tests passed offline in Debian.
- Release build passed on wspr5; the final executable was installed and tested with the companion module.
- Requested 14.097100 MHz GPIO20 TONE ran for approximately 10.002 seconds, with matching module divider readback and successful cleanup. Repeated execution and supported reboot recovery passed.
- Adversarial findings were repaired and reassessed. Exact builds and failed/successful target captures are recorded in the module repository under docs/evidence/runtime-tone-20260831/.

The full unrelated application suite and visual UI tests were not run; no visual UI files changed. WSPR/QRSS and analyzer frequency qualification remain untested. The Harness needs a separate ping/pong client fix; it is unchanged here. The original INI, served UI and masked normal service were preserved; target tests used a temporary GPIO20 configuration and transient loopback service.

Documentation impact: runtime-route-workflow.md updated. Operator documentation in the separate Wsprry_Pi_Docs repository was not changed. No new licensing provenance was imported.

Companion module PR: https://github.com/WsprryPi/RP1-GPCLK-DKMS/pull/8.
