### PR TITLE
Restore WsprryPi in idle mode after runtime route switching

### DIFF
--- a/WsprryPi-UI/data/index.js
+++ b/WsprryPi-UI/data/index.js
@@ -2354,9 +2354,12 @@ function clickTransmitPin() {
 }
 
 const RP1_ROUTE_STATES = Object.freeze({
-    runtime_inhibited: ["Output disabled", "Runtime route administration is available. Switching stops Wsprry Pi; verify completion with the operator client."],
+    runtime_inhibited: ["Output disabled", "Switching restarts a running Wsprry Pi in idle mode. Transmission does not resume."],
+    runtime_ready: ["Route ready", "Route switching is complete. Transmission was not resumed."],
+    runtime_restoring: ["Restoring application", "Wsprry Pi is reconnecting on the selected route. Refresh status shortly."],
+    runtime_restoration_failed: ["Application restoration failed", "Run runtime_route_client.py restore --execute to retry application restoration without switching the overlay."],
     runtime_recovery: ["Recovery required", "Inspect the controller error and ownership before explicit cleanup recovery."],
-    runtime_unknown: ["Completion unknown", "The application disconnected. Do not retry the switch. Run runtime_route_client.py query to inspect the result; transmission must remain inhibited."],
+    runtime_unknown: ["Reconnecting", "Wsprry Pi disconnected during route administration. Refresh this page after it restarts; if it remains unavailable, run runtime_route_client.py query. Do not repeat the switch."],
     checking: ["Checking", "Checking the external provider and active route…"],
     active: ["Active", "Requested and active routes match. No reboot is required."],
     reboot_required: ["Reboot required", "Review the requested route, then apply it and reboot or cancel the draft."],
@@ -2390,7 +2393,7 @@ class Rp1RouteUiController {
         const draft=this.routeValue(`GPIO${getTxPin()}`);
         const changed=draft!=="Unavailable" && draft!==this.active;
         const recovery=["staged","mismatch","rollback_required","runtime_recovery"].includes(state);
-        $("#rp1-route-apply").prop("disabled",this.inFlight || this.completionUnknown || recovery || state==="runtime_unknown" || !changed);
+        $("#rp1-route-apply").prop("disabled",this.inFlight || this.completionUnknown || ["runtime_restoring","runtime_restoration_failed"].includes(state) || recovery || state==="runtime_unknown" || !changed);
         $("#rp1-route-cancel").prop("disabled",this.inFlight || draft===this.persisted);
         $("#rp1-route-rollback").prop("hidden",!recovery).prop("disabled",this.inFlight);
     }
@@ -2443,7 +2446,7 @@ class Rp1RouteUiController {
     }
     async operate(operation) {
         if(this.runtimeProfile && operation==="rollback") {
-            if(!window.confirm("Recover to no route? Wsprry Pi will stop and remain masked. Verify the result with the operator client before further administration.")) return;
+            if(!window.confirm("Recover to no route? Wsprry Pi will stop and remain inhibited. Verify the result with the operator client before further administration.")) return;
             operation="recover";
         }
         const requested=this.routeValue(`GPIO${getTxPin()}`);
@@ -2466,7 +2469,7 @@ class Rp1RouteUiController {
             if(!preflightResponse.ok || preflight.ok!==true){this.inFlight=false;this.render(preflight);return;}
             this.generation=preflight.generation;
             const confirmed=window.confirm(this.runtimeProfile
-                ? `Switch to ${requested} with output disabled? Wsprry Pi will stop and remain masked. This browser may disconnect. Verify completion using runtime_route_client.py query. No reboot is requested.`
+                ? `Switch to ${requested} with output disabled? A running Wsprry Pi will restart in idle mode. This browser may disconnect; refresh after it reconnects. Transmission will not resume. No reboot is requested.`
                 :
                 `Apply ${requested} and reboot? The package executor will stop only wsprrypi.service and soapyremote-server.service before changing its owned boot block.`
             );

--- a/WsprryPi-UI/data/views/config.php
+++ b/WsprryPi-UI/data/views/config.php
@@ -765,7 +765,7 @@ $bandGpioBands = ['2200m', '630m', '160m', '80m', '60m', '40m', '30m', '20m', '1
                                             <dl class="rp1-route-identities" aria-label="RP1 clock route state">
                                                 <div><dt>Requested</dt><dd id="rp1-route-requested">—</dd></div>
                                                 <div><dt>Persisted</dt><dd id="rp1-route-persisted">—</dd></div>
-                                                <div><dt>Boot configured</dt><dd id="rp1-route-configured">—</dd></div>
+                                                <div><dt>Configured</dt><dd id="rp1-route-configured">—</dd></div>
                                                 <div><dt>Active</dt><dd id="rp1-route-active">—</dd></div>
                                                 <div><dt>Module reported</dt><dd id="rp1-route-module">—</dd></div>
                                                 <div><dt>Reconciled</dt><dd id="rp1-route-reconciled">No</dd></div>

--- a/WsprryPi-UI/tests/rp1_route_ui_test.js
+++ b/WsprryPi-UI/tests/rp1_route_ui_test.js
@@ -5,7 +5,7 @@ const view=fs.readFileSync(path.join(root,"data/views/config.php"),"utf8");
 const script=fs.readFileSync(path.join(root,"data/index.js"),"utf8");
 const styles=fs.readFileSync(path.join(root,"data/index.css"),"utf8");
 const header=fs.readFileSync(path.join(root,"data/header.php"),"utf8");
-assert.match(view,/Requested[\s\S]*Persisted[\s\S]*Boot configured[\s\S]*Active[\s\S]*Module reported[\s\S]*Reconciled[\s\S]*Boot ownership[\s\S]*Pending transaction[\s\S]*Fixed services[\s\S]*Endpoint[\s\S]*live_output[\s\S]*Development policy[\s\S]*Operation lifecycle[\s\S]*Product qualification/);
+assert.match(view,/Requested[\s\S]*Persisted[\s\S]*Configured[\s\S]*Active[\s\S]*Module reported[\s\S]*Reconciled[\s\S]*Boot ownership[\s\S]*Pending transaction[\s\S]*Fixed services[\s\S]*Endpoint[\s\S]*live_output[\s\S]*Development policy[\s\S]*Operation lifecycle[\s\S]*Product qualification/);
 assert.match(view,/>Apply route and reboot</); assert.match(view,/>Cancel</);
 assert.match(view,/role="status" aria-live="polite" aria-atomic="true"/);
 for(const state of ["checking","active","reboot_required","applying","staged","mismatch","unavailable","rollback","rollback_required"])
@@ -61,5 +61,10 @@ vm.runInContext(script.slice(script.indexOf("const RP1_ROUTE_STATES"),script.ind
  context.window.confirm=()=>false;
  await controller.operate("rollback");
  assert.equal(requests.length,1,"cancelled recovery has no effect");
+ controller.render({profile:"runtime",ok:true,state:"runtime_ready",persisted:"GPIO20",active:"GPIO20"});
+ assert.equal(element("rp1-route-state").textContent,"Route ready");
+ controller.render({profile:"runtime",ok:false,state:"runtime_restoration_failed",persisted:"GPIO20",active:"GPIO4"});
+ assert.equal(element("rp1-route-apply").disabled,true,"restoration failure cannot launch another switch");
+ assert.match(element("rp1-route-feedback").textContent,/restore --execute/);
  console.log("runtime route UI behavior: PASS");
 })().catch(error=>{console.error(error);process.exitCode=1});

--- a/docs/runtime-route-restoration-review.md
+++ b/docs/runtime-route-restoration-review.md
@@ -1,0 +1,48 @@
+<!-- SPDX-License-Identifier: MIT -->
+
+# Runtime route restoration review, 2026-08-31
+
+The application companion, startup policy, readiness acknowledgement and route
+feedback were reviewed alongside the DKMS restoration transaction. No kernel,
+UAPI or reusable transmitter-component source changed in this application work.
+
+Repaired findings included saving the pin before an overlay succeeded,
+automatic transmission through Always/Follow startup preferences, startup lock
+contention, listener readiness, stale completion presentation, and bootstrap installation resolving
+the helper relative to the invoking script instead of the selected checkout.
+The final reassessment found no remaining actionable findings in the implemented
+canonical-service workflow and offline validation scope.
+
+Validation passed:
+
+- Debian release build with the default compiled backend set.
+- Route-service and runtime-wiring C++ tests, including readiness messages,
+  deferred configuration ownership and stale-controller presentation.
+- Seven configuration/installer companion tests, including atomic failure,
+  preservation of unrelated content and file mode, all three boot policies,
+  missing/old installations and bootstrap/dry-run behavior.
+- Complete `semantics-test` in a fresh network-disabled Debian container,
+  including idle restoration overriding Never, Follow and Always without
+  changing the saved boot preference.
+- Route UI behavior tests, installer shell syntax and whitespace checks.
+- Impeccable desktop/mobile inspection of the existing route panel with local
+  assets and no page network access; no horizontal overflow. Failed preflight
+  and lost-connection tests verified that switches are not retried automatically.
+
+The initial broad semantics run used mixed Mac/Linux build artifacts and failed
+to execute those artifacts. The isolated rerun passed. A C++ comparison error
+found during iteration was fixed before the final targeted build/test pass.
+
+## Documentation Impact
+
+Updated `docs/runtime-route-workflow.md` describes successful idle restoration,
+stopped/masked behavior, installation, explicit recovery and limitations.
+The separate Wsprry_Pi_Docs repository was inspected but not modified: follow-up
+updates belong in `docs/Install/index.md`,
+`docs/Advanced_Operations/rest_api.md` and
+`docs/Advanced_Operations/websocket.md` after this coordinated implementation
+is selected for deployment. That repository is outside this task's write scope.
+
+No target installation, service operation, reboot, GPIO change or RF testing was
+performed. Actual systemd restoration and clock-disabled route switching remain
+target validation, not established by these offline results.

--- a/docs/runtime-route-workflow.md
+++ b/docs/runtime-route-workflow.md
@@ -15,25 +15,51 @@ and persists the requested route separately from controller-reported active stat
 Recovery explicitly asks the controller to reach no route; it is not a rollback
 to a previous GPIO. Removal errors retain their kernel errno and overlay ID.
 
-The manager stops and persistently masks WsprryPi before route changes. The UI
-therefore warns that its HTTP connection may disappear. A disconnect means
-completion unknown, disables further switch attempts until fresh state is read,
-and directs the operator to `runtime_route_client.py query`. Subsequent operations
-while WsprryPi is stopped use that client. Nothing automatically unmasks, restarts,
-or authorizes output. A permanently available browser administration service is
-not provided by this change.
+The manager temporarily inhibits systemd starts using its own service drop-in,
+stops WsprryPi, and switches the owned runtime overlay with output disabled.
+It does not overwrite the installed service unit or an administrator's mask.
+After the route is verified idle, the installed WsprryPi companion updates the
+saved pin and disables transmission. A previously running application restarts
+in idle mode; a previously stopped or administrator-masked application stays
+stopped. Saved `Enable on Boot` preferences and unrelated configuration remain
+unchanged. A stopped application's first subsequent startup is also idle.
 
-Install/update/recovery belong to the module repository's separately reviewed
-runtime bundle workflow. This application commit does not install it, replace a
-running binary, change services, migrate a firmware route, reboot, or test GPIO.
-Coherent target deployment and clock-disabled GPIO4/GPIO20 switching still need
-separate authorization and proof. No product or RF qualification is claimed.
+The browser may disconnect when its application stops. Refresh after the
+application restarts. Do not repeat a switch merely because the connection was
+lost: `runtime_route_client.py query` reports the durable transaction. Application
+readiness is acknowledged only after startup reconciliation, loop setup and
+binding the HTTP listener when enabled; a
+systemd start request alone is not success. The UI distinguishes restoration in
+progress, successful completion, route recovery, and application restoration
+failure. Completed records describe the last transaction, not future uptime.
 
-The manager can explicitly release its application mask with `resume gpio20
---execute` after validating the idle runtime route. Start the application only
-after that request returns. The existing ABI-v4 lease supports authorized output
-with the module loaded at `live_output=0`; no globally enabled load is needed.
-Route changes still stop and mask the application.
+`runtime_route_client.py restore --execute` retries incomplete application
+restoration on the installed route without repeating overlay removal/application.
+An interrupted route change requires `recover --execute`, followed by a new
+explicit switch. Prior-boot state is never used to restart automatically.
+Transmission is not resumed by either switching or restoration; the normal
+operator controls and existing RP1 operation authorization remain available.
+
+The application installer and `scripts/copy_exe.py` install
+`/usr/local/lib/wsprrypi/route_application.py` with the executable. Use a matching,
+newly bound DKMS runtime bundle supporting `applicationRestorationVersion=1`.
+The companion supports the canonical `/usr/local/bin/wsprrypi -J -i
+/usr/local/etc/wsprrypi.ini` service command, optionally with `--no-web`.
+It refuses missing services, unsupported command overrides, alternate config
+paths or old binaries before stopping the application. Administrator-owned
+units using that command are preserved. An old service mask from a previous
+manual deployment must be reviewed during installation; it is not automatically
+removed or assumed to belong to this workflow.
+
+The startup-only `WSPRRYPI_ROUTE_RESTORE_IDLE` environment value is supplied by
+the manager's owned drop-in. It is not a transmission permit or operator setting.
+Startup forces `Transmit=false` while preserving the stored boot preference;
+the token binds the application's readiness acknowledgement to this transaction.
+
+These changes have offline software validation only. Coherent target deployment,
+clock-disabled route switching and actual service restart still require separate
+authorization and target evidence. No module installation, GPIO changes, reboot
+or RF operation is performed by the offline test suite.
 
 Bounded-tone start acknowledgements are asynchronous. A response includes an
 RP1 operation record only when it belongs to that request; the terminal record

--- a/scripts/copy_exe.py
+++ b/scripts/copy_exe.py
@@ -100,6 +100,9 @@ def main():
         run(["sudo", "systemctl", "stop", SERVICE_NAME])
 
     try:
+        run(["sudo", "install", "-d", "-o", "root", "-g", "root", "-m", "0755", "/usr/local/lib/wsprrypi"])
+        install_file(git_root / "scripts" / "route_application.py",
+                     Path("/usr/local/lib/wsprrypi/route_application.py"))
         install_file(source, INSTALL_PATH)
     finally:
         if was_active:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5997,6 +5997,15 @@ manage_support_bundle_runtime() {
     debug_end "$debug"
 }
 
+# Install the application-owned route companion from the selected checkout.
+manage_route_application() {
+    if [[ "$ACTION" == "install" && "$DRY_RUN" != "true" ]]; then
+        install -d -o root -g root -m 0755 /usr/local/lib/wsprrypi || return 1
+        install -o root -g root -m 0755 "${LOCAL_REPO_DIR}/scripts/route_application.py" \
+            /usr/local/lib/wsprrypi/route_application.py || return 1
+    fi
+}
+
 # -----------------------------------------------------------------------------
 # @brief Manages the installation or removal of configuration files.
 # @details This function installs or removes a configuration file. During
@@ -7980,6 +7989,7 @@ manage_wsprry_pi() {
         "compile_binary \"$WSPR_EXE\""
         "manage_exe \"$WSPR_EXE\""
         "manage_support_bundle_runtime"
+        "manage_route_application"
         "manage_config \"$WSPR_INI\" \"/usr/local/etc/\""
         "manage_i2c"
         "manage_service \"/usr/bin/$WSPR_EXE\" \"$service_command\" \"false\""

--- a/scripts/route_application.py
+++ b/scripts/route_application.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Fixed-path companion for DKMS route restoration; no hardware operations.
+
+Only the canonical installed service/configuration is managed. INI edits retain
+all bytes except the two selected values. No service or module is started here.
+"""
+import configparser
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+
+CONFIG = Path('/usr/local/etc/wsprrypi.ini')
+BINARY = Path('/usr/local/bin/wsprrypi')
+CONTRACT = 'wsprrypi-route-application-v1'
+
+
+def trusted(path):
+    for parent in reversed(path.parents):
+        info = parent.lstat()
+        if not stat.S_ISDIR(info.st_mode) or info.st_uid or info.st_mode & 0o022:
+            raise ValueError('untrusted parent: ' + str(parent))
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode) or info.st_uid or info.st_mode & 0o022:
+            raise ValueError('untrusted file: ' + str(path))
+        with os.fdopen(fd, 'rb', closefd=False) as stream:
+            data = stream.read(64 * 1024 * 1024 + 1)
+        if len(data) > 64 * 1024 * 1024:
+            raise ValueError('file too large')
+        return data, info
+    finally:
+        os.close(fd)
+
+
+def configuration(data):
+    parser = configparser.ConfigParser(interpolation=None, strict=True)
+    parser.optionxform = str
+    parser.read_string(data.decode('utf-8'))
+    if parser.defaults():
+        raise ValueError('inherited configuration is not supported')
+    if parser.get('Operation', 'Transmit Backend').lower() != 'rp1-gpclk':
+        raise ValueError('installed configuration must select rp1-gpclk')
+    if parser.get('Operation', 'Mode').upper() not in ('WSPR', 'QRSS', 'FSKCW', 'DFCW'):
+        raise ValueError('managed idle restoration requires a scheduled application mode')
+    parser.getboolean('Operation', 'Transmit')
+    if parser.get('Operation', 'Enable on Boot').lower() not in ('never', 'follow', 'always'):
+        raise ValueError('invalid boot policy')
+    if parser.getint('GPIO', 'Transmit Pin') not in (4, 20):
+        raise ValueError('invalid saved route')
+    return parser
+
+
+def edit(data, route):
+    configuration(data)
+    if route not in ('gpio4', 'gpio20'):
+        raise ValueError('invalid route')
+    replacements = {('GPIO', 'Transmit Pin'): route[4:], ('Operation', 'Transmit'): 'False'}
+    section = None
+    seen = set()
+    lines = []
+    for line in data.decode('utf-8').splitlines(keepends=True):
+        header = re.fullmatch(r'\s*\[([^\]]+)\]\s*', line)
+        if header:
+            section = header[1]
+        match = re.fullmatch(r'([^=\r\n]+?\s*=\s*)([^\r\n]*)(\r?\n)?', line)
+        if match:
+            key = (section, match[1].split('=', 1)[0].strip())
+            if key in replacements:
+                if key in seen:
+                    raise ValueError('duplicate route configuration')
+                seen.add(key)
+                line = match[1] + replacements[key] + (match[3] or '')
+        lines.append(line)
+    if seen != set(replacements):
+        raise ValueError('explicit route and transmit assignments required')
+    result = ''.join(lines).encode('utf-8')
+    configuration(result)
+    return result
+
+
+def inspect_service():
+    output = subprocess.check_output(['/usr/bin/systemctl', 'show', 'wsprrypi.service',
+        '--property=ExecStart', '--value'], text=True, timeout=10)
+    # systemd's fixed argv[] representation; reject alternate configs, command
+    # chains and CLI output overrides instead of guessing which file to edit.
+    match = re.fullmatch(r'\{ path=/usr/local/bin/wsprrypi ; argv\[\]=([^;]+) ; .*\}\s*', output)
+    if not match or match[1].split() not in (
+            ['/usr/local/bin/wsprrypi', '-J', '-i', str(CONFIG)],
+            ['/usr/local/bin/wsprrypi', '-J', '-i', str(CONFIG), '--no-web']):
+        raise ValueError('service is missing, masked, or uses an unsupported command; preserve it and repair installation')
+    binary, _ = trusted(BINARY)
+    if b'WSPRRYPI_ROUTE_RESTORE_IDLE' not in binary:
+        raise ValueError('installed application lacks idle restoration support')
+
+
+def configure(route):
+    data, info = trusted(CONFIG)
+    result = edit(data, route)
+    if result == data:
+        return
+    fd, name = tempfile.mkstemp(prefix='.route-', dir=CONFIG.parent)
+    try:
+        with os.fdopen(fd, 'wb') as stream:
+            os.fchmod(stream.fileno(), stat.S_IMODE(info.st_mode))
+            os.fchown(stream.fileno(), info.st_uid, info.st_gid)
+            stream.write(result)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if trusted(CONFIG)[0] != data:
+            raise ValueError('configuration changed during route update')
+        os.replace(name, CONFIG)
+        directory = os.open(CONFIG.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        if os.path.exists(name):
+            os.unlink(name)
+
+
+def main(args):
+    if os.geteuid() != 0:
+        raise ValueError('root required')
+    if args == ['inspect']:
+        inspect_service()
+    elif args == ['inspect-stopped']:
+        if b'WSPRRYPI_ROUTE_RESTORE_IDLE' not in trusted(BINARY)[0]:
+            raise ValueError('installed application lacks idle restoration support')
+    elif len(args) == 2 and args[0] == 'configure':
+        configure(args[1])
+    else:
+        raise ValueError('usage: route_application.py inspect | configure gpio4|gpio20')
+    parser = configuration(trusted(CONFIG)[0])
+    print(json.dumps({'contract': CONTRACT, 'route': 'gpio'+str(parser.getint('GPIO', 'Transmit Pin')),
+                      'transmit': parser.getboolean('Operation', 'Transmit'), 'config': str(CONFIG)}))
+
+
+if __name__ == '__main__':
+    try:
+        main(sys.argv[1:])
+    except (OSError, ValueError, configparser.Error, subprocess.SubprocessError) as error:
+        sys.exit(str(error))

--- a/scripts/tests/route_application_test.py
+++ b/scripts/tests/route_application_test.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Offline tests of the installed route configuration companion."""
+import os
+from pathlib import Path
+import sys
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import route_application as app
+
+SOURCE = Path(__file__).resolve().parents[2]
+
+
+class Tests(unittest.TestCase):
+    def setUp(self):
+        self.data = (SOURCE/'config/wsprrypi.ini').read_bytes().replace(
+            b'Transmit Backend = gpio', b'Transmit Backend = rp1-gpclk')
+
+    def test_only_pin_and_transmit_change_for_all_boot_policies(self):
+        for policy in (b'Never', b'Follow', b'Always'):
+            original = self.data.replace(b'Enable on Boot = Never', b'Enable on Boot = '+policy).replace(
+                b'Transmit = False', b'Transmit = True')
+            expected = original.replace(b'Transmit Pin = 4', b'Transmit Pin = 20').replace(
+                b'Transmit = True', b'Transmit = False')
+            self.assertEqual(app.edit(original, 'gpio20'), expected)
+            self.assertEqual(app.edit(expected, 'gpio20'), expected)
+
+    def test_crlf_and_unknown_settings_are_preserved(self):
+        data = self.data.replace(b'\n', b'\r\n')+b'\r\n[Custom]\r\nValue = literal%value\r\n'
+        self.assertEqual(app.edit(data, 'gpio20'), data.replace(b'Transmit Pin = 4', b'Transmit Pin = 20'))
+
+    def test_invalid_duplicate_and_wrong_backend_do_not_edit(self):
+        for data in (self.data+b'\n[GPIO]\nTransmit Pin = 20\n',
+                     self.data.replace(b'Transmit Backend = rp1-gpclk', b'Transmit Backend = gpio'),
+                     self.data.replace(b'Transmit Pin = 4', b'Transmit Pin = 19'),
+                     self.data.replace(b'Enable on Boot = Never', b'Enable on Boot = unknown')):
+            with self.assertRaises(Exception): app.edit(data, 'gpio20')
+
+    def test_atomic_configuration_and_mode_preservation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory)/'application.ini'
+            path.write_bytes(self.data)
+            path.chmod(0o640)
+            with patch.object(app, 'CONFIG', path), patch.object(app, 'trusted', side_effect=lambda p:(p.read_bytes(), p.stat())), patch.object(os, 'fchown'):
+                app.configure('gpio20')
+            self.assertEqual(path.read_bytes(), app.edit(self.data, 'gpio20'))
+            self.assertEqual(path.stat().st_mode & 0o777, 0o640)
+            self.assertEqual(list(Path(directory).iterdir()), [path])
+
+    def test_failed_replace_keeps_original(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory)/'application.ini'
+            path.write_bytes(self.data)
+            with patch.object(app, 'CONFIG', path), patch.object(app, 'trusted', side_effect=lambda p:(p.read_bytes(), p.stat())), patch.object(os, 'fchown'), patch.object(os, 'replace', side_effect=OSError('crash')):
+                with self.assertRaises(OSError): app.configure('gpio20')
+            self.assertEqual(path.read_bytes(), self.data)
+
+    def test_installed_service_layouts_and_old_binary_rejection(self):
+        for suffix in ('', ' --no-web'):
+            text = '{ path=/usr/local/bin/wsprrypi ; argv[]=/usr/local/bin/wsprrypi -J -i /usr/local/etc/wsprrypi.ini'+suffix+' ; ignore_errors=no ; }\n'
+            with patch.object(app.subprocess, 'check_output', return_value=text), patch.object(app, 'trusted', return_value=(b'WSPRRYPI_ROUTE_RESTORE_IDLE', None)):
+                app.inspect_service()
+            with patch.object(app.subprocess, 'check_output', return_value=text), patch.object(app, 'trusted', return_value=(b'old binary', None)):
+                with self.assertRaises(ValueError): app.inspect_service()
+        with patch.object(app.subprocess, 'check_output', return_value=''):
+            with self.assertRaises(ValueError): app.inspect_service()
+
+    def test_bootstrap_installer_uses_selected_checkout_and_honors_dry_run(self):
+        source = (SOURCE/'scripts/install.sh').read_text()
+        function = source.split('manage_route_application() {', 1)[1].split('\n}\n', 1)[0]
+        function = 'manage_route_application() {'+function+'\n}\n'
+        for dry_run in ('true', 'false'):
+            script = ('install() { printf "%s\\n" "$*"; }\n'+function+
+                'ACTION=install\nLOCAL_REPO_DIR=/selected-checkout\nDRY_RUN='+dry_run+
+                '\nmanage_route_application\n')
+            result = subprocess.check_output(['bash', '-c', script], text=True, cwd='/tmp')
+            if dry_run == 'true':
+                self.assertEqual(result, '')
+            else:
+                self.assertIn('/selected-checkout/scripts/route_application.py', result)
+                self.assertIn('/usr/local/lib/wsprrypi/route_application.py', result)
+
+
+if __name__ == '__main__': unittest.main()

--- a/src/Makefile
+++ b/src/Makefile
@@ -1550,6 +1550,7 @@ $(BIN_DIR)/$(RP1_GPCLK_ROUTE_SERVICE_TEST_OUT): tests/rp1_gpclk_route_service_te
 
 rp1-gpclk-route-service-test: $(BIN_DIR)/$(RP1_GPCLK_ROUTE_SERVICE_TEST_OUT)
 	$(Q)./$(BIN_DIR)/$(RP1_GPCLK_ROUTE_SERVICE_TEST_OUT)
+	$(Q)python3 ../scripts/tests/route_application_test.py
 
 $(BIN_DIR)/$(RP1_GPCLK_TRANSMIT_BACKEND_TEST_OUT): WSPR-Transmitter/src/rp1_gpclk_transmit_backend_test.cpp WSPR-Transmitter/src/rp1_gpclk_transmit_backend.cpp WSPR-Transmitter/src/rp1_gpclk_development_policy.cpp WSPR-Transmitter/src/rp1_gpclk_event_program.cpp WSPR-Transmitter/src/rp1_gpclk_backend.cpp WSPR-Transmitter/src/rp1_gpclk_linux_provider.cpp WSPR-Transmitter/src/rp1_gpclk_planner.cpp WSPR-Transmitter/src/rp1_gpclk_reconciliation.cpp Chipset-Offsets/src/chipset_offsets.hpp
 	$(Q)mkdir -p $(BIN_DIR)

--- a/src/config_handler.cpp
+++ b/src/config_handler.cpp
@@ -2656,6 +2656,16 @@ void json_to_ini()
 
 bool apply_enable_on_boot_startup_policy()
 {
+    // A route restoration restarts the application, never its transmission.
+    // This startup-only override leaves the saved boot preference unchanged.
+    if (std::getenv("WSPRRYPI_ROUTE_RESTORE_IDLE") != nullptr)
+    {
+        config.transmit = false;
+        config_to_json();
+        json_to_ini();
+        return true;
+    }
+
     switch (config.enable_on_boot)
     {
     case EnableOnBootBehavior::Never:

--- a/src/rp1_gpclk_route_service.cpp
+++ b/src/rp1_gpclk_route_service.cpp
@@ -180,7 +180,7 @@ nlohmann::json Rp1GpclkRouteService::render(const nlohmann::json &response,
   }
   const auto &state = response["state"];
   if (runtime_profile_) {
-    auto result = failure("runtime_inhibited", "Runtime administration keeps transmission disabled. Switching stops and masks Wsprry Pi; use the operator client to verify completion.");
+    auto result = failure("runtime_inhibited", "Switching restarts a running Wsprry Pi in idle mode. Transmission does not resume.");
     const bool valid = state.is_object() && state.value("profile", std::string{}) == "runtime" &&
         state.contains("outputEnabled") && state["outputEnabled"] == false &&
         state.contains("qualification") && state["qualification"] == false &&
@@ -196,13 +196,51 @@ nlohmann::json Rp1GpclkRouteService::render(const nlohmann::json &response,
     result["bootOwnership"] = "runtime controller";
     result["journal"] = state.contains("pendingTransaction") && state["pendingTransaction"].is_object()
         ? field(state["pendingTransaction"], "phase") : "none";
-    result["preflightValidated"] = valid && status == "ok" && field(state, "preflightToken").size() == 64;
+    result["preflightValidated"] = valid && status == "ok" &&
+        state.value("applicationRestorationVersion", 0) == 1 && field(state, "preflightToken").size() == 64;
+    if (!field(state, "preflightToken").empty() && state.value("applicationRestorationVersion", 0) != 1) {
+      result["message"] = "Upgrade the route manager before switching: this version cannot restore application availability.";
+    }
     result["controller"] = state.value("controller", nlohmann::json::object());
     if (valid) {
       const auto phase = result["journal"].get<std::string>();
       if ((state["controller"].value("flags", 0) & 1) ||
           (phase != "none" && phase != "complete-inhibited" && phase != "recovered-inhibited"))
         result["state"] = "runtime_recovery";
+    }
+    if (state.contains("application") && state["application"].is_object()) {
+      const auto &application = state["application"];
+      const auto phase = field(application, "phase");
+      result["application"] = application;
+      result["services"] = {{"wsprrypi.service", phase}};
+      if ((phase == "restored" || phase == "stopped" || phase == "administrator-masked") &&
+          valid && application.value("controller", nlohmann::json::object()) == state["controller"] &&
+          state["controller"].value("flags", 0) == 6 && state["controller"].value("error", -1) == 0 &&
+          routeForGpio(operations_.persisted_gpio()) == field(result, "active") &&
+          field(application, "boot") == field(state, "bootId") &&
+          field(application, "binding") == field(state, "bindingSha256")) {
+        result["state"] = "runtime_ready";
+        result["configured"] = result["active"];
+        result["reconciled"] = true;
+        result["journal"] = "none";
+        result["message"] = phase == "restored"
+            ? "Last route switch restored Wsprry Pi in idle mode. Transmission was not resumed."
+            : phase == "stopped" ? "Route switched; Wsprry Pi remains stopped as requested by its prior state."
+            : "Route switched; the administrator's service mask is preserved.";
+      } else if (phase == "restored" || phase == "stopped" || phase == "administrator-masked") {
+        result["state"] = "runtime_recovery";
+        result["ok"] = false;
+        result["message"] = "The last restoration record does not match the current route and application configuration. Inspect the route before switching.";
+      } else if (phase == "restoration-failed") {
+        result["state"] = "runtime_restoration_failed";
+        result["ok"] = false;
+        result["message"] = "Route is installed, but application restoration failed. Run runtime_route_client.py restore --execute. " + field(application, "error");
+      } else if (phase == "route-failed" || phase == "route-recovered") {
+        result["state"] = "runtime_recovery";
+      } else {
+        result["state"] = "runtime_restoring";
+        result["message"] = "Route administration is in progress. Refresh status after Wsprry Pi reconnects.";
+      }
     }
     if (response.contains("error")) {
       result["message"] = field(response["error"], "message");
@@ -271,6 +309,20 @@ nlohmann::json Rp1GpclkRouteService::render(const nlohmann::json &response,
                                                                  : "disabled")
                : nlohmann::json("unknown")}};
 }
+bool Rp1GpclkRouteService::acknowledgeRestoration(const std::string &token,
+                                                 bool transmit) {
+  std::lock_guard<std::mutex> guard(mutex_);
+  if (transmit || !idle() || startup_failure_latched_)
+    return false;
+  const int gpio = operations_.persisted_gpio();
+  if (gpio != 4 && gpio != 20)
+    return false;
+  const auto reply = request({{"schemaVersion", 3}, {"operation", "application-ready"},
+      {"route", gpio == 4 ? "gpio4" : "gpio20"}, {"token", token},
+      {"pid", static_cast<int>(::getpid())}, {"transmit", false}});
+  return reply.value("status", std::string{}) == "ok";
+}
+
 nlohmann::json Rp1GpclkRouteService::query() {
   std::lock_guard<std::mutex> guard(mutex_);
   return render(request({{"schemaVersion", 1}, {"operation", "query"}}));
@@ -316,9 +368,8 @@ nlohmann::json Rp1GpclkRouteService::operate(const std::string &operation,
       value["preflightToken"] = runtime_token_;
       // The token binds the ID across application restarts as well as preflights.
       value["requestId"] = "wsprrypi-" + runtime_token_.substr(0, 48);
-      std::string error;
-      if (!operations_.persist_gpio || !operations_.persist_gpio(gpio, &error))
-        return failure("persistence_failed", error);
+      // The privileged completion workflow persists the pin only after the
+      // overlay succeeds, independently of this application's lifetime.
     }
     runtime_token_.clear();
     preflight_route_.clear();

--- a/src/rp1_gpclk_route_service.hpp
+++ b/src/rp1_gpclk_route_service.hpp
@@ -17,6 +17,7 @@ class Rp1GpclkRouteService {
 public:
   explicit Rp1GpclkRouteService(Rp1GpclkRouteExecutorOperations);
   nlohmann::json query();
+  bool acknowledgeRestoration(const std::string &token, bool transmit);
   nlohmann::json operate(const std::string &, const std::string &,
                          std::uint64_t);
   nlohmann::json reconcileStartup();

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -5057,6 +5057,24 @@ bool wspr_loop()
         }
     }
 
+    if (const char *restoration = std::getenv("WSPRRYPI_ROUTE_RESTORE_IDLE"))
+    {
+        const auto listener_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (start_web && network_safety_ready && !webServer.isListening() &&
+               std::chrono::steady_clock::now() < listener_deadline)
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        if (startup_quiesce_inhibited.load(std::memory_order_acquire) ||
+            !network_safety_ready || (start_web && !webServer.isListening()) ||
+            config.transmit_backend != TransmitBackendKind::RP1_GPCLK ||
+            !wsprrypi::productionRp1GpclkRouteService().acknowledgeRestoration(
+                restoration, config.transmit))
+        {
+            llog.logS(ERROR, "Route restoration could not acknowledge idle application readiness.");
+            stop_runtime_components_for_process_exit();
+            return false;
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Loop (block wspr_loop only) until shutdown is triggered
     // -------------------------------------------------------------------------

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -4865,6 +4865,19 @@ int main(int argc, char *argv[])
             "/tmp/enable_on_boot_startup_always.ini",
             "Enable on Boot Always must enable and persist Operation.Transmit on startup");
 
+        setenv("WSPRRYPI_ROUTE_RESTORE_IDLE", "offline-restoration", 1);
+        for (auto policy : {EnableOnBootBehavior::Never,
+                            EnableOnBootBehavior::Follow,
+                            EnableOnBootBehavior::Always})
+        {
+            exercise_startup_policy(policy, true, false,
+                "/tmp/route_restoration_startup.ini",
+                "Route restoration must persist idle startup for every boot policy");
+            require(config.enable_on_boot == policy,
+                "Route restoration must preserve the saved boot preference");
+        }
+        unsetenv("WSPRRYPI_ROUTE_RESTORE_IDLE");
+
         auto exercise_managed_startup_gate =
             [](EnableOnBootBehavior behavior,
                bool startup_config_handoff,

--- a/src/tests/rp1_gpclk_route_runtime_wiring_test.cpp
+++ b/src/tests/rp1_gpclk_route_runtime_wiring_test.cpp
@@ -51,6 +51,10 @@ int main() {
     assert(request_commit != std::string::npos);
     assert(listener_start != std::string::npos);
     assert(idle_startup < listener_start);
+    const auto restoration_ack = scheduling.find(".acknowledgeRestoration(");
+    const auto listener_ready = scheduling.find("!webServer.isListening()");
+    assert(restoration_ack != std::string::npos && listener_ready > listener_start && listener_ready < restoration_ack);
+    assert(http.find("return svr && svr->is_running();") != std::string::npos);
     assert(bounded_request < development_reconciliation);
     assert(development_reconciliation < request_commit);
     const auto direct_confirmation = scheduling.find(

--- a/src/tests/rp1_gpclk_route_service_test.cpp
+++ b/src/tests/rp1_gpclk_route_service_test.cpp
@@ -387,7 +387,7 @@ int main() {
   next = {{"schemaVersion", 3}, {"contract", "rp1-gpclk-route-manager-runtime-v1"},
           {"status", "ok"}, {"state", {{"profile", "runtime"}, {"activeRoute", "gpio4"},
           {"outputEnabled", false}, {"qualification", false}, {"controller", {{"id", 9}}},
-          {"preflightToken", std::string(64, 'a')}}}};
+          {"applicationRestorationVersion", 1}, {"preflightToken", std::string(64, 'a')}}}};
   assert(service.query().at("profile") == "runtime");
   assert(inhibited);
   auto runtime_preflight = service.operate("preflight", "GPIO20", 0);
@@ -396,9 +396,11 @@ int main() {
   assert(requests.back().at("schemaVersion") == 3);
   assert(service.operate("switch", "GPIO20", runtime_generation + 1).at("ok") == false);
   assert(service.operate("apply-and-reboot", "GPIO20", runtime_generation).at("ok") == false);
+  const int saved_before_runtime_switch = persisted;
   next["status"] = "complete-inhibited";
   assert(service.operate("switch", "GPIO20", runtime_generation).at("ok") == true);
   assert(requests.back().at("operation") == "switch");
+  assert(persisted == saved_before_runtime_switch);
   assert(requests.back().at("preflightToken") == std::string(64, 'a'));
   assert(inhibited);
   assert(service.operate("switch", "GPIO20", runtime_generation).at("ok") == false);
@@ -446,6 +448,24 @@ int main() {
   runtime["state"]["outputLifecycle"]["executionAuthorized"] = true;
   assert(runtime_service.reconcileDevelopmentStartup("GPIO20").at("ok") == false);
   assert(runtime_inhibited);
+
+  runtime["state"]["outputLifecycle"] = lifecycle;
+  assert(!runtime_service.acknowledgeRestoration("offline-token", true));
+  assert(runtime_service.acknowledgeRestoration("offline-token", false));
+  assert(runtime_requests.back().at("operation") == "application-ready");
+  assert(runtime_requests.back().at("route") == "gpio20");
+  assert(runtime_requests.back().at("transmit") == false);
+  runtime["state"]["activeRoute"] = "gpio20";
+  runtime["state"]["application"] = {{"phase","restored"}, {"controller",ctl},
+      {"boot","current-boot"}, {"binding",std::string(64,'a')}};
+  auto restored = runtime_service.query();
+  assert(restored.at("state") == "runtime_ready" && restored.at("reconciled") == true);
+  runtime["state"]["controller"]["flags"] = 7;
+  assert(runtime_service.query().at("state") == "runtime_recovery");
+  runtime["state"]["controller"] = ctl;
+  runtime["state"]["application"]["phase"] = "restoration-failed";
+  runtime["state"]["application"]["error"] = "start failed";
+  assert(runtime_service.query().at("state") == "runtime_restoration_failed");
 
   std::cout << "rp1_gpclk_route_service_test: PASS\n";
 }

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -172,6 +172,12 @@ WebServer::WebServer() : port_(0), running(false) {}
  */
 WebServer::~WebServer() { stop(); }
 
+bool WebServer::isListening()
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    return svr && svr->is_running();
+}
+
 /**
  * @brief Sets the Cross-Origin Resource Sharing (CORS) headers on the HTTP
  * response.

--- a/src/web_server.hpp
+++ b/src/web_server.hpp
@@ -88,6 +88,9 @@ public:
      */
     void start(int port);
 
+    // True only after the HTTP listener has bound, not merely after thread start.
+    bool isListening();
+
     /**
      * @brief Stops the web server.
      *


### PR DESCRIPTION
## Purpose

Restore a usable idle application after successful runtime route switching, without resuming transmission or saving a new pin before the overlay succeeds.

## Changes

- Install the application-owned configuration companion with the executable.
- Preserve saved boot preferences while forcing idle restoration startup.
- Acknowledge readiness only after route reconciliation, startup checks and listener readiness.
- Present completed restoration and recoverable failures accurately in the route UI.

## Validation

Fresh network-disabled Debian release build, complete semantics suite, route-service and runtime-wiring tests passed. Seven companion tests, route UI behavior, desktop/mobile visual review and shell/whitespace checks passed. Adversarial findings were repaired and reassessed. No hardware or deployment activity occurred.

Companion module branch: WsprryPi/RP1-GPCLK-DKMS codex/route-application-restoration (fe245b8).
