### PR TITLE
Implement RP1 GPCLK DKMS installation contract

### DIFF
--- a/.github/workflows/debian-non-hardware.yml
+++ b/.github/workflows/debian-non-hardware.yml
@@ -179,7 +179,8 @@ jobs:
           make support-bundle-retention-audit-test SUDO=
           make support-bundle-retention-deletion-test SUDO=
           make support-bundle-contract-reconciliation-test SUDO=
-          make support-bundle-age-dependency-test installer-dependency-test SUDO=
+          make support-bundle-age-dependency-test installer-dependency-test \
+            rp1-gpclk-dkms-installer-test SUDO=
           make support-bundle-intake-validation-test SUDO=
           make support-bundle-intake-state-test SUDO=
           make support-bundle-intake-retrieval-test SUDO=

--- a/README.md
+++ b/README.md
@@ -39,14 +39,15 @@ building, explicit selection, deterministic virtual-time traces, bounded
 real-time tests, fault injection, repeated execution, Debian CI, and the limits
 of simulation evidence.
 
-RP1 GPCLK support is compiled into the application as a consumer of an
-externally provisioned `/dev/rp1-gpclk` provider. WsprryPi does not install,
-remove, package, attest, or validate the provenance of that provider. Runtime
-use still validates the provider protocol, required capabilities, selected
-route, exclusive operation ownership, bounded requests, and cleanup state.
-Those checks establish application compatibility only; they do not qualify
-installation, GPIO behavior, timing, frequency accuracy, spectral performance,
-or RF output.
+RP1 GPCLK support is compiled into the application as a consumer of the
+independently maintained `/dev/rp1-gpclk` provider. On Pi 5-family systems the
+installer can resolve and validate an eligible published provider release; it
+also supports fail-closed exact-source development selection. See the
+[RP1-GPCLK-DKMS installation contract](docs/rp1-gpclk-dkms-installation.md).
+WsprryPi preserves the provider on uninstall and never selects a route, loads
+the module, or enables output as part of provider installation. Runtime checks
+establish application compatibility only; they do not qualify installation,
+GPIO behavior, timing, frequency accuracy, spectral performance, or RF output.
 
 ## Installation
 

--- a/docs/rp1-gpclk-dkms-installation.md
+++ b/docs/rp1-gpclk-dkms-installation.md
@@ -88,11 +88,17 @@ qualification remain separate facts.
 
 ## Plan, record, and safety boundary
 
-Before package mutation the installer displays the WsprryPi channel, detected
-platform, selection reason and override state, requested and resolved source,
-immutable tag or commit, version and expected hashes, lifecycle command class,
-and the output-disabled boundary. Dry-run mode resolves and validates the plan
-but does not apply it.
+Before package mutation a real installation displays the WsprryPi channel,
+detected platform, selection reason and override state, requested and resolved
+source, immutable tag or commit, version and expected hashes, lifecycle command
+class, and the output-disabled boundary. With `DRY_RUN=true`, the standard
+installer command wrapper reports both RP1 planning and application commands
+as skipped and does not invoke Python, download or clone provider inputs, run
+upstream preflight, inspect a package, or mutate provider state. Debug mode
+shows the exact helper command; during a real run it also reports the helper's
+external command argv and captured validation output. The resolved plan and
+ordinary package/DKMS or upstream lifecycle output remain visible during a real
+installation even when debug mode is off.
 
 After successful verification, current provider identity is recorded at
 `/var/lib/wsprrypi/rp1-gpclk-dkms-installation.json`. This record describes

--- a/docs/rp1-gpclk-dkms-installation.md
+++ b/docs/rp1-gpclk-dkms-installation.md
@@ -1,0 +1,101 @@
+# RP1-GPCLK-DKMS installation
+
+WsprryPi can orchestrate installation of the independently maintained
+[`WsprryPi/RP1-GPCLK-DKMS`](https://github.com/WsprryPi/RP1-GPCLK-DKMS)
+provider. WsprryPi does not vendor its module source, reproduce its DKMS
+lifecycle, select a GPIO route, edit boot configuration, load the module, or
+enable output.
+
+## Selection
+
+`INSTALL_RP1_GPCLK_DKMS` accepts exactly:
+
+- `auto` (default): install only on a positively identified Raspberry Pi 5 or
+  Compute Module 5 with BCM2712 compatibility;
+- `true`: request installation on any platform, without bypassing provider
+  hardware, resource, ownership, or build checks; or
+- `false`: deliberately omit provider installation.
+
+`RP1_GPCLK_DKMS_SOURCE` accepts exactly:
+
+- `auto` (default): select a published release for WsprryPi `main`/release
+  installation, or the DKMS `origin/devel` tip for a named non-production
+  WsprryPi branch;
+- `release`: select the latest eligible published stable release;
+- `devel`: resolve upstream `origin/devel` once to a full commit;
+- `commit:FULL_40_CHARACTER_SHA`: select an exact upstream commit; or
+- `checkout:/absolute/path`: select the clean HEAD of an authoritative local
+  checkout.
+
+Abbreviated commits, relative or symlinked checkout paths, dirty or unrelated
+repositories, unavailable branches or commits, and ambiguous WsprryPi source
+channels are refused. An explicit source selector can resolve an otherwise
+ambiguous WsprryPi source channel, but never weakens source verification.
+
+Examples:
+
+```sh
+sudo INSTALL_RP1_GPCLK_DKMS=false ./scripts/install.sh
+
+sudo INSTALL_RP1_GPCLK_DKMS=true \
+  RP1_GPCLK_DKMS_SOURCE=commit:0123456789abcdef0123456789abcdef01234567 \
+  ./scripts/install.sh
+```
+
+## Published releases
+
+Release selection enumerates published, immutable, non-draft, non-prerelease
+semantic versions rather than following a `latest` redirect. A candidate must provide
+exactly one Debian package plus `SHA256SUMS` and
+`rp1-gpclk-dkms-installation-manifest-v1.json`. The selected manifest binds:
+
+- repository, release tag, immutable tag commit, product and Debian versions,
+  and release-channel classification;
+- package filename, package/DKMS/kernel-module identities, and package SHA-256;
+- supported UAPI ABI range, installed UAPI path and SHA-256;
+- `rp1-gpclk-route-manager-v1`;
+- route-neutral, output-disabled package behavior with no module load, overlay
+  application, boot-configuration edit, or service operation; and
+- a canonical checksummed inventory of every package data member.
+
+The installer validates authoritative asset URLs, GitHub asset digests when
+present, tag resolution, the checksum file, manifest consistency, Debian control identity, safe archive paths and
+symlinks, complete package inventory, and UAPI identity before package-manager
+mutation. If the highest selected release is corrupt, validation stops; an
+older release is not silently substituted. Historical releases without this
+manifest are not eligible.
+
+An exact installed release is verified idempotently. Foreign, mixed,
+development, active, enrolled, manager-bound, or different-version state is
+refused and must be handled by its owning migration or recovery procedure.
+WsprryPi uninstall preserves the provider.
+
+## Development sources
+
+Development selection clones or validates the authoritative repository,
+records a full commit, checks out that commit detached when applicable, rejects
+tracked or untracked changes, and revalidates checkout identity immediately
+before mutation. It runs the upstream preflight and exact-source installer only
+when that maintained interface supports route-neutral installation with output
+disabled and without loading the module.
+
+The present upstream exact-source lifecycle requires a concrete GPIO route.
+That is not a route-neutral installation contract, so development installation
+currently fails before mutation and identifies the missing upstream interface.
+WsprryPi does not guess a route or bypass that refusal. Development identity
+remains `v0.9.0-pi5`; exact commit, kernel, route, hashes, enrollment, and
+qualification remain separate facts.
+
+## Plan, record, and safety boundary
+
+Before package mutation the installer displays the WsprryPi channel, detected
+platform, selection reason and override state, requested and resolved source,
+immutable tag or commit, version and expected hashes, lifecycle command class,
+and the output-disabled boundary. Dry-run mode resolves and validates the plan
+but does not apply it.
+
+After successful verification, current provider identity is recorded at
+`/var/lib/wsprrypi/rp1-gpclk-dkms-installation.json`. This record describes
+source/package state only. It is not a signature, route selection, hardware or
+kernel qualification, GPIO permission, transmission authority, or RF evidence.
+No failure selects a fallback backend.

--- a/docs/rp1-gpclk-dkms-installation.md
+++ b/docs/rp1-gpclk-dkms-installation.md
@@ -44,6 +44,10 @@ sudo INSTALL_RP1_GPCLK_DKMS=true \
 
 ## Published releases
 
+No eligible RP1-GPCLK-DKMS release is currently published. Production/main
+selection therefore fails closed until the canonical release is prepared with
+the contract below; it does not fall back to development source.
+
 Release selection enumerates published, immutable, non-draft, non-prerelease
 semantic versions rather than following a `latest` redirect. A candidate must provide
 exactly one Debian package plus `SHA256SUMS` and
@@ -75,16 +79,17 @@ WsprryPi uninstall preserves the provider.
 Development selection clones or validates the authoritative repository,
 records a full commit, checks out that commit detached when applicable, rejects
 tracked or untracked changes, and revalidates checkout identity immediately
-before mutation. It runs the upstream preflight and exact-source installer only
-when that maintained interface supports route-neutral installation with output
-disabled and without loading the module.
+before mutation. The upstream preflight derives the development module version
+from the exact checkout's canonical source header and binds that header by hash.
+WsprryPi does not infer a development version from release metadata
+or supply a version to the upstream installer.
 
-The present upstream exact-source lifecycle requires a concrete GPIO route.
-That is not a route-neutral installation contract, so development installation
-currently fails before mutation and identifies the missing upstream interface.
-WsprryPi does not guess a route or bypass that refusal. Development identity
-remains `v0.9.0-pi5`; exact commit, kernel, route, hashes, enrollment, and
-qualification remain separate facts.
+The maintained exact-source installer must provide route-neutral installation
+with output disabled and without loading the module. WsprryPi verifies the
+returned exact commit, canonical version, kernel, UAPI, installed module hashes,
+null route, and output-disabled state before recording success. Development
+identity remains `v0.9.0-pi5`; exact commit, kernel, route, hashes, enrollment,
+and qualification remain separate facts.
 
 ## Plan, record, and safety boundary
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,20 @@
 
 These scripts are used for install and development orchestration.
 
+## RP1-GPCLK-DKMS provider
+
+`install.sh` uses `rp1_gpclk_dkms_install.py` to resolve and validate the
+independently owned provider before package mutation. Automatic Pi 5/CM5,
+explicit override/opt-out, published release, immutable development source,
+dry-run, existing-state refusal, and provider-preserving uninstall behavior are
+documented in [RP1-GPCLK-DKMS installation](../docs/rp1-gpclk-dkms-installation.md).
+
+Run its offline hardware-free contract coverage with:
+
+```sh
+python3 scripts/tests/rp1_gpclk_dkms_install_test.py
+```
+
 ## Support-bundle collector
 
 ### Future support-route guard

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,9 @@ independently owned provider before package mutation. Automatic Pi 5/CM5,
 explicit override/opt-out, published release, immutable development source,
 dry-run, existing-state refusal, and provider-preserving uninstall behavior are
 documented in [RP1-GPCLK-DKMS installation](../docs/rp1-gpclk-dkms-installation.md).
+Dry-run uses the installer's standard command wrapper and never starts the
+Python helper. Passing `debug` displays the helper command and, for a real run,
+its external command activity and captured output.
 
 Run its offline hardware-free contract coverage with:
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1895,14 +1895,20 @@ remove_slash() {
 # shellcheck disable=SC2317
 # shellcheck disable=SC2329
 exec_command() {
-    # Start debug and filter parameters
-    local debug status
-    debug=$(debug_start "$@")
-    eval set -- "$(debug_filter "$@")"
+    # The documented debug control is a trailing wrapper argument. Preserve
+    # command arguments named "debug" anywhere else with exact argv fidelity.
+    local debug="" status
+    if (( $# > 0 )) && [[ "${!#}" == "debug" ]]; then
+        debug=$(debug_start "debug")
+        set -- "${@:1:$(($# - 1))}"
+    else
+        debug=$(debug_start)
+    fi
 
     # Declare local variables after debug initialization
     local status=0 exec_name running_pre complete_pre failed_pre
     local args cmd cmd_str
+    local show_output="${EXEC_COMMAND_SHOW_OUTPUT:-false}"
 
     # Assign the human readable name and shift it off
     exec_name="$1"; shift
@@ -1944,15 +1950,16 @@ exec_command() {
         return 0
     fi
 
-    # Execute the command, swallowing output unless debug is enabled
-    if [[ "$debug" == "debug" ]]; then
+    # Execute the command, swallowing output unless debug or an explicitly
+    # reviewed caller requires ordinary command output in the installer log.
+    if [[ "$debug" == "debug" || "$show_output" == "true" ]]; then
         "${cmd[@]}" || status=$?
     else
         "${cmd[@]}" &>/dev/null || status=$?
     fi
 
-    # Clear running status line only when not in debug mode
-    if [[ "$debug" != "debug" ]]; then
+    # Preserve visible command output instead of erasing its final line.
+    if [[ "$debug" != "debug" && "$show_output" != "true" ]]; then
         printf "%b%b" "$MOVE_UP" "$CLEAR_LINE"
     fi
 
@@ -2219,6 +2226,11 @@ is_pi5() {
 # -----------------------------------------------------------------------------
 cleanup_rp1_gpclk_dkms_state() {
     local state_dir="${RP1_GPCLK_DKMS_STATE_DIR:-}"
+    if [[ "$state_dir" == "dry-run:no-state-created" ]]; then
+        RP1_GPCLK_DKMS_STATE_DIR=""
+        RP1_GPCLK_DKMS_HELPER=""
+        return 0
+    fi
     if [[ -z "$state_dir" || ! -d "$state_dir" || -L "$state_dir" ]]; then
         return 0
     fi
@@ -2251,28 +2263,35 @@ prepare_rp1_gpclk_dkms_installation() {
 
     [[ "$ACTION" == "install" ]] || return 0
 
-    RP1_GPCLK_DKMS_STATE_DIR=$(mktemp -d /tmp/wsprrypi-rp1-gpclk-dkms.XXXXXX)
-    chmod 0700 "$RP1_GPCLK_DKMS_STATE_DIR"
-
     local script_source="${BASH_SOURCE[0]:-}"
     local local_helper=""
     if [[ -n "$script_source" && "$script_source" != "bash" ]]; then
         local_helper="$(cd "$(dirname "$script_source")" && pwd -P)/rp1_gpclk_dkms_install.py"
     fi
 
-    RP1_GPCLK_DKMS_HELPER="$RP1_GPCLK_DKMS_STATE_DIR/rp1_gpclk_dkms_install.py"
-    if [[ -n "$local_helper" && -f "$local_helper" && ! -L "$local_helper" ]]; then
-        cp -- "$local_helper" "$RP1_GPCLK_DKMS_HELPER"
-        chmod 0700 "$RP1_GPCLK_DKMS_HELPER"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        # Use stable display-only paths. exec_command() deliberately does not
+        # execute Python in dry-run mode, so no helper download, temporary
+        # directory, network resolution, package inspection, or preflight runs.
+        RP1_GPCLK_DKMS_STATE_DIR="dry-run:no-state-created"
+        RP1_GPCLK_DKMS_HELPER="${local_helper:-dry-run:no-helper-downloaded}"
     else
-        local helper_url="${GIT_RAW_BASE}/${REPO_ORG}/${REPO_NAME}/${REPO_BRANCH}/scripts/rp1_gpclk_dkms_install.py"
-        if ! curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
-            --output "$RP1_GPCLK_DKMS_HELPER" "$helper_url"; then
-            warn "Unable to retrieve the RP1-GPCLK-DKMS installer helper from $helper_url."
-            cleanup_rp1_gpclk_dkms_state
-            return 1
+        RP1_GPCLK_DKMS_STATE_DIR=$(mktemp -d /tmp/wsprrypi-rp1-gpclk-dkms.XXXXXX)
+        chmod 0700 "$RP1_GPCLK_DKMS_STATE_DIR"
+        RP1_GPCLK_DKMS_HELPER="$RP1_GPCLK_DKMS_STATE_DIR/rp1_gpclk_dkms_install.py"
+        if [[ -n "$local_helper" && -f "$local_helper" && ! -L "$local_helper" ]]; then
+            cp -- "$local_helper" "$RP1_GPCLK_DKMS_HELPER"
+            chmod 0700 "$RP1_GPCLK_DKMS_HELPER"
+        else
+            local helper_url="${GIT_RAW_BASE}/${REPO_ORG}/${REPO_NAME}/${REPO_BRANCH}/scripts/rp1_gpclk_dkms_install.py"
+            if ! curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
+                --output "$RP1_GPCLK_DKMS_HELPER" "$helper_url"; then
+                warn "Unable to retrieve the RP1-GPCLK-DKMS installer helper from $helper_url."
+                cleanup_rp1_gpclk_dkms_state
+                return 1
+            fi
+            chmod 0700 "$RP1_GPCLK_DKMS_HELPER"
         fi
-        chmod 0700 "$RP1_GPCLK_DKMS_HELPER"
     fi
 
     local prepare_args=(
@@ -2285,8 +2304,12 @@ prepare_rp1_gpclk_dkms_installation() {
     if [[ "$DRY_RUN" == "true" ]]; then
         prepare_args+=(--dry-run)
     fi
+    if [[ "$debug" == "debug" ]]; then
+        prepare_args+=(--debug)
+    fi
 
-    if ! python3 "$RP1_GPCLK_DKMS_HELPER" "${prepare_args[@]}"; then
+    if ! EXEC_COMMAND_SHOW_OUTPUT=true exec_command "Resolve RP1-GPCLK-DKMS installation plan" \
+        python3 "$RP1_GPCLK_DKMS_HELPER" "${prepare_args[@]}" "$debug"; then
         warn "RP1-GPCLK-DKMS installation planning failed before package mutation."
         cleanup_rp1_gpclk_dkms_state
         return 1
@@ -2308,17 +2331,18 @@ apply_rp1_gpclk_dkms_installation() {
     eval set -- "$(debug_filter "$@")"
 
     [[ "$ACTION" == "install" ]] || return 0
-    if [[ "$DRY_RUN" == "true" ]]; then
-        logI "Dry run: RP1-GPCLK-DKMS plan validated; no provider mutation performed."
-        debug_end "$debug"
-        return 0
-    fi
-    if [[ -z "${RP1_GPCLK_DKMS_STATE_DIR:-}" || -z "${RP1_GPCLK_DKMS_HELPER:-}" ]]; then
+    if [[ "$DRY_RUN" != "true" && \
+        ( -z "${RP1_GPCLK_DKMS_STATE_DIR:-}" || -z "${RP1_GPCLK_DKMS_HELPER:-}" ) ]]; then
         warn "RP1-GPCLK-DKMS plan state is unavailable."
         return 1
     fi
-    if ! python3 "$RP1_GPCLK_DKMS_HELPER" apply \
-        --state-dir "$RP1_GPCLK_DKMS_STATE_DIR"; then
+
+    local apply_args=(apply --state-dir "$RP1_GPCLK_DKMS_STATE_DIR")
+    if [[ "$debug" == "debug" ]]; then
+        apply_args+=(--debug)
+    fi
+    if ! EXEC_COMMAND_SHOW_OUTPUT=true exec_command "Apply RP1-GPCLK-DKMS installation plan" \
+        python3 "$RP1_GPCLK_DKMS_HELPER" "${apply_args[@]}" "$debug"; then
         warn "RP1-GPCLK-DKMS installation failed closed; inspect the retained installer log and provider state."
         return 1
     fi
@@ -8410,11 +8434,13 @@ main() {
 #          exits. This enables proper session cleanup and displays session
 #          statistics to the user.
 # -----------------------------------------------------------------------------
-trap egress EXIT
+if [[ -z "${BASH_SOURCE[0]:-}" || "${BASH_SOURCE[0]}" == "$0" ]]; then
+    trap egress EXIT
 
-debug=$(debug_start "$@")
-eval set -- "$(debug_filter "$@")"
-main "$@" "$debug"
-retval="$?"
-debug_end "$debug"
-exit "$retval"
+    debug=$(debug_start "$@")
+    eval set -- "$(debug_filter "$@")"
+    main "$@" "$debug"
+    retval="$?"
+    debug_end "$debug"
+    exit "$retval"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -223,6 +223,10 @@ declare GIT_CLONE_BASE="https://github.com"
 declare FAIL_ON_UI_MODIFICATIONS="${FAIL_ON_UI_MODIFICATIONS:-false}"
 declare UI_PUBLICATION_ATTEMPTED="false"
 declare UI_PUBLICATION_RESULT_FILE=""
+declare INSTALL_RP1_GPCLK_DKMS="${INSTALL_RP1_GPCLK_DKMS:-auto}"
+declare RP1_GPCLK_DKMS_SOURCE="${RP1_GPCLK_DKMS_SOURCE:-auto}"
+declare RP1_GPCLK_DKMS_STATE_DIR=""
+declare RP1_GPCLK_DKMS_HELPER=""
 
 # -----------------------------------------------------------------------------
 # Declare Arguments Variables
@@ -533,6 +537,7 @@ if [[ -z "${SUPPORTED_MODELS+x}" || ${#SUPPORTED_MODELS[@]} -eq 0 ]]; then
     SUPPORTED_MODELS=(
         # Supported models
         ["Raspberry Pi 5|5-model-b|bcm2712"]="Supported"
+        ["Raspberry Pi Compute Module 5|5-compute-module|bcm2712"]="Supported"
         ["Raspberry Pi 400|400|bcm2711"]="Supported"
         ["Raspberry Pi Compute Module 4S|4s-compute-module|bcm2711"]="Supported"
         ["Raspberry Pi Compute Module 4|4-compute-module|bcm2711"]="Supported"
@@ -665,7 +670,9 @@ declare -ar DEPENDENCIES=(
     "whoami"
     "touch"
     "dpkg"
+    "dpkg-deb"
     "dpkg-reconfigure"
+    "python3"
     "curl"
     "wget"
     "realpath"
@@ -977,6 +984,7 @@ declare REBOOT=${REBOOT:-false}
 egress() {
     local status=$?
     report_ui_publication_result
+    cleanup_rp1_gpclk_dkms_state
     return "$status"
 }
 
@@ -2152,12 +2160,22 @@ print_model_name() {
     # Read and process the compatible string
     if ! detected_model=$(tr '\0' '\n' </proc/device-tree/compatible 2>/dev/null \
         | sed -n 's/raspberrypi,//p'); then
+        if [[ "$INSTALL_RP1_GPCLK_DKMS" == "true" ]]; then
+            warn "Platform model detection is unavailable; continuing because RP1 provider installation was explicitly requested."
+            debug_end "$debug"
+            return 0
+        fi
         debug_end "$debug"
         die 1 "Failed to read or process /proc/device-tree/compatible."
     fi
 
     # Ensure a model was detected
     if [[ -z "${detected_model:-}" ]]; then
+        if [[ "$INSTALL_RP1_GPCLK_DKMS" == "true" ]]; then
+            warn "This system is not identified as a Raspberry Pi; continuing because RP1 provider installation was explicitly requested."
+            debug_end "$debug"
+            return 0
+        fi
         debug_end "$debug"
         die 1 "No Raspberry Pi model found in /proc/device-tree/compatible."
     fi
@@ -2172,6 +2190,12 @@ print_model_name() {
         fi
     done
 
+    if [[ "$INSTALL_RP1_GPCLK_DKMS" == "true" ]]; then
+        warn "Detected Raspberry Pi model '$detected_model' is not recognized; continuing because RP1 provider installation was explicitly requested."
+        debug_end "$debug"
+        return 0
+    fi
+
     debug_end "$debug"
     die 1 "Detected Raspberry Pi model '$detected_model' is not recognized."
 }
@@ -2184,7 +2208,122 @@ is_pi5() {
         return 1
     fi
 
-    [[ "${detected_model:-}" == "5-model-b" ]]
+    [[ "${detected_model:-}" == "5-model-b" || \
+        "${detected_model:-}" == "5-compute-module" ]]
+}
+
+# -----------------------------------------------------------------------------
+# @brief Remove only the fresh RP1 provider planning directory from this run.
+# @details The independently owned installed provider and its operational record
+#          are deliberately preserved. This cleanup owns only mktemp output.
+# -----------------------------------------------------------------------------
+cleanup_rp1_gpclk_dkms_state() {
+    local state_dir="${RP1_GPCLK_DKMS_STATE_DIR:-}"
+    if [[ -z "$state_dir" || ! -d "$state_dir" || -L "$state_dir" ]]; then
+        return 0
+    fi
+    case "$state_dir" in
+        /tmp/wsprrypi-rp1-gpclk-dkms.*|/var/tmp/wsprrypi-rp1-gpclk-dkms.*)
+            rm -rf -- "$state_dir"
+            ;;
+        *)
+            warn "Refusing to remove unexpected RP1 provider state directory: $state_dir"
+            return 1
+            ;;
+    esac
+    RP1_GPCLK_DKMS_STATE_DIR=""
+    RP1_GPCLK_DKMS_HELPER=""
+    return 0
+}
+
+# -----------------------------------------------------------------------------
+# @brief Resolve and validate the RP1-GPCLK-DKMS installation before mutation.
+# @details Uses the checked-out helper when available. A streamed installer
+#          retrieves the helper from the exact WsprryPi source selector already
+#          chosen for this installer invocation. The helper enumerates and
+#          validates release metadata or resolves an immutable development
+#          source before any package-manager operation.
+# -----------------------------------------------------------------------------
+prepare_rp1_gpclk_dkms_installation() {
+    local debug
+    debug=$(debug_start "$@")
+    eval set -- "$(debug_filter "$@")"
+
+    [[ "$ACTION" == "install" ]] || return 0
+
+    RP1_GPCLK_DKMS_STATE_DIR=$(mktemp -d /tmp/wsprrypi-rp1-gpclk-dkms.XXXXXX)
+    chmod 0700 "$RP1_GPCLK_DKMS_STATE_DIR"
+
+    local script_source="${BASH_SOURCE[0]:-}"
+    local local_helper=""
+    if [[ -n "$script_source" && "$script_source" != "bash" ]]; then
+        local_helper="$(cd "$(dirname "$script_source")" && pwd -P)/rp1_gpclk_dkms_install.py"
+    fi
+
+    RP1_GPCLK_DKMS_HELPER="$RP1_GPCLK_DKMS_STATE_DIR/rp1_gpclk_dkms_install.py"
+    if [[ -n "$local_helper" && -f "$local_helper" && ! -L "$local_helper" ]]; then
+        cp -- "$local_helper" "$RP1_GPCLK_DKMS_HELPER"
+        chmod 0700 "$RP1_GPCLK_DKMS_HELPER"
+    else
+        local helper_url="${GIT_RAW_BASE}/${REPO_ORG}/${REPO_NAME}/${REPO_BRANCH}/scripts/rp1_gpclk_dkms_install.py"
+        if ! curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
+            --output "$RP1_GPCLK_DKMS_HELPER" "$helper_url"; then
+            warn "Unable to retrieve the RP1-GPCLK-DKMS installer helper from $helper_url."
+            cleanup_rp1_gpclk_dkms_state
+            return 1
+        fi
+        chmod 0700 "$RP1_GPCLK_DKMS_HELPER"
+    fi
+
+    local prepare_args=(
+        prepare
+        --state-dir "$RP1_GPCLK_DKMS_STATE_DIR"
+        --install "$INSTALL_RP1_GPCLK_DKMS"
+        --source "$RP1_GPCLK_DKMS_SOURCE"
+        --wsprry-source "$REPO_BRANCH"
+    )
+    if [[ "$DRY_RUN" == "true" ]]; then
+        prepare_args+=(--dry-run)
+    fi
+
+    if ! python3 "$RP1_GPCLK_DKMS_HELPER" "${prepare_args[@]}"; then
+        warn "RP1-GPCLK-DKMS installation planning failed before package mutation."
+        cleanup_rp1_gpclk_dkms_state
+        return 1
+    fi
+    debug_end "$debug"
+    return 0
+}
+
+# -----------------------------------------------------------------------------
+# @brief Apply the previously validated RP1 provider plan.
+# @details Dry runs stop after rendering the plan. Real installations revalidate
+#          prepared inputs and invoke only the package manager or the reviewed
+#          upstream exact-source lifecycle. No overlay, route, load, service,
+#          GPIO, output, transmission, or RF operation is performed.
+# -----------------------------------------------------------------------------
+apply_rp1_gpclk_dkms_installation() {
+    local debug
+    debug=$(debug_start "$@")
+    eval set -- "$(debug_filter "$@")"
+
+    [[ "$ACTION" == "install" ]] || return 0
+    if [[ "$DRY_RUN" == "true" ]]; then
+        logI "Dry run: RP1-GPCLK-DKMS plan validated; no provider mutation performed."
+        debug_end "$debug"
+        return 0
+    fi
+    if [[ -z "${RP1_GPCLK_DKMS_STATE_DIR:-}" || -z "${RP1_GPCLK_DKMS_HELPER:-}" ]]; then
+        warn "RP1-GPCLK-DKMS plan state is unavailable."
+        return 1
+    fi
+    if ! python3 "$RP1_GPCLK_DKMS_HELPER" apply \
+        --state-dir "$RP1_GPCLK_DKMS_STATE_DIR"; then
+        warn "RP1-GPCLK-DKMS installation failed closed; inspect the retained installer log and provider state."
+        return 1
+    fi
+    debug_end "$debug"
+    return 0
 }
 
 # -----------------------------------------------------------------------------
@@ -2567,6 +2706,12 @@ validate_sys_accs() {
     # Iterate through system files
     for file in "${SYSTEM_READS[@]}"; do
         if [[ ! -r "$file" ]]; then
+            if [[ "$file" == "/proc/device-tree/compatible" && \
+                "$INSTALL_RP1_GPCLK_DKMS" == "true" ]]; then
+                warn "Missing or unreadable platform identity: $file; continuing because RP1 provider installation was explicitly requested."
+                debug_print "Explicit RP1 provider override permits missing platform identity: $file" "$debug"
+                continue
+            fi
             warn "Missing or unreadable file: $file"
             ((missing++))
             debug_print "Missing or unreadable file: $file" "$debug"
@@ -2888,12 +3033,22 @@ check_arch() {
 
     # Read and process the compatible string
     if ! detected_model=$(tr '\0' '\n' </proc/device-tree/compatible 2>/dev/null | sed -n 's/raspberrypi,//p'); then
+        if [[ "$INSTALL_RP1_GPCLK_DKMS" == "true" ]]; then
+            warn "Platform architecture detection is unavailable; continuing because RP1 provider installation was explicitly requested."
+            debug_end "$debug"
+            return 0
+        fi
         debug_end "$debug"
         die 1 "Failed to read or process /proc/device-tree/compatible. Ensure compatibility."
     fi
 
     # Check if the detected model is empty
     if [[ -z "${detected_model:-}" ]]; then
+        if [[ "$INSTALL_RP1_GPCLK_DKMS" == "true" ]]; then
+            warn "This system has no recognized Raspberry Pi architecture; continuing because RP1 provider installation was explicitly requested."
+            debug_end "$debug"
+            return 0
+        fi
         debug_end "$debug"
         die 1 "No Raspberry Pi model found in /proc/device-tree/compatible. This system may not be supported."
     fi
@@ -2907,6 +3062,11 @@ check_arch() {
                 is_supported=true
                 debug_print "Model: '$full_name' ($chip) is supported." "$debug"
             else
+                if [[ "$INSTALL_RP1_GPCLK_DKMS" == "true" ]]; then
+                    warn "Model '$full_name' ($chip) is normally unsupported; continuing because RP1 provider installation was explicitly requested."
+                    debug_end "$debug"
+                    return 0
+                fi
                 debug_end "$debug"
                 die 1 "Model: '$full_name' ($chip) is not supported."
             fi
@@ -2949,6 +3109,11 @@ check_arch() {
 
     # Log an error if no supported model was found
     if [[ "$is_supported" == false ]]; then
+        if [[ "$INSTALL_RP1_GPCLK_DKMS" == "true" ]]; then
+            warn "Detected Raspberry Pi model '$detected_model' is not recognized or supported; continuing because RP1 provider installation was explicitly requested."
+            debug_end "$debug"
+            return 0
+        fi
         debug_end "$debug"
         die 1 "Detected Raspberry Pi model '$detected_model' is not recognized or supported."
     fi
@@ -8173,6 +8338,13 @@ _main() {
     check_arch "$debug"        # Validate Raspberry Pi model compatibility
     check_internet "$debug"    # Verify internet connectivity if required
 
+    # Resolve the independently owned RP1 provider before any package-manager
+    # mutation. Automatic selection skips non-Pi-5/unknown systems, while an
+    # explicit true request is only an installation override.
+    if [[ "$ACTION" != "uninstall" ]]; then
+        prepare_rp1_gpclk_dkms_installation "$debug" || return 1
+    fi
+
     # Start the script
     start_script "$debug"
 
@@ -8194,6 +8366,7 @@ _main() {
     if [[ "$ACTION" != "uninstall" ]]; then
         handle_apt_packages "$debug" || return 1
         validate_support_bundle_age_dependency "$debug" || return 1
+        apply_rp1_gpclk_dkms_installation "$debug" || return 1
     fi
 
     # Handle correcting timezone

--- a/scripts/rp1_gpclk_dkms_install.py
+++ b/scripts/rp1_gpclk_dkms_install.py
@@ -14,6 +14,7 @@ import os
 import pathlib
 import platform
 import re
+import shlex
 import stat
 import subprocess
 import sys
@@ -113,30 +114,47 @@ class CommandResult:
 
 
 class Runner:
+    def __init__(self, debug: bool = False):
+        self.debug = debug
+
+    def trace(self, argv: Sequence[str], cwd: pathlib.Path | None = None) -> None:
+        if self.debug:
+            location = f" (cwd={cwd})" if cwd is not None else ""
+            print(f"[RP1 DEBUG] command{location}: {shlex.join(str(item) for item in argv)}", file=sys.stderr)
+
     def run(
         self,
         argv: Sequence[str],
         *,
         check: bool = True,
         cwd: pathlib.Path | None = None,
+        passthrough: bool = False,
     ) -> CommandResult:
+        self.trace(argv, cwd)
         try:
-            process = subprocess.run(
-                list(argv),
-                cwd=cwd,
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=False,
-            )
+            if passthrough:
+                process = subprocess.run(list(argv), cwd=cwd, text=True, check=False)
+            else:
+                process = subprocess.run(
+                    list(argv), cwd=cwd, text=True, stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE, check=False,
+                )
         except FileNotFoundError as error:
             result = CommandResult("", f"required command is unavailable: {argv[0]}", 127)
             if check:
                 raise ContractError(result.stderr) from error
             return result
-        result = CommandResult(process.stdout, process.stderr, process.returncode)
+        result = CommandResult(process.stdout or "", process.stderr or "", process.returncode)
+        if self.debug and not passthrough:
+            if result.stdout:
+                print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+            if result.stderr:
+                print(result.stderr, end="" if result.stderr.endswith("\n") else "\n", file=sys.stderr)
         if check and process.returncode:
-            detail = process.stderr.strip() or process.stdout.strip() or "no diagnostic"
+            if passthrough:
+                detail = "see command output above"
+            else:
+                detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic"
             raise ContractError(f"command failed ({argv[0]}): {detail}")
         return result
 
@@ -432,8 +450,10 @@ def validate_package(path: pathlib.Path, manifest: Mapping[str, Any], runner: Ru
     ]
     require(control == [PACKAGE_NAME, manifest["debianVersion"], "all"], "Debian control identity differs from manifest")
     tar_path = path.parent / "data.tar"
+    fsys_command = ["dpkg-deb", "--fsys-tarfile", str(path)]
+    runner.trace(fsys_command)
     process = subprocess.Popen(
-        ["dpkg-deb", "--fsys-tarfile", str(path)],
+        fsys_command,
         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
     )
     expanded = 0
@@ -450,6 +470,8 @@ def validate_package(path: pathlib.Path, manifest: Mapping[str, Any], runner: Ru
     assert process.stderr is not None
     stderr = process.stderr.read().decode(errors="replace").strip()
     returncode = process.wait()
+    if runner.debug and stderr:
+        print(stderr, file=sys.stderr)
     require(returncode == 0, f"dpkg-deb could not expose package inventory: {stderr}")
     try:
         actual = tar_inventory(tar_path)
@@ -888,7 +910,10 @@ def apply_release(state_dir: pathlib.Path, resolved: Mapping[str, Any], record: 
             and not inventory["moduleCandidates"] and not inventory["installedOverlays"],
             "foreign or mixed RP1 GPCLK installation blocks package installation",
         )
-        runner.run(["apt-get", "install", "--no-install-recommends", "-y", str(package_path)])
+        runner.run(
+            ["apt-get", "install", "--no-install-recommends", "-y", str(package_path)],
+            passthrough=True,
+        )
     elif inventory["packageVersion"] == expected:
         pass
     else:
@@ -968,7 +993,7 @@ def apply_development(resolved: Mapping[str, Any], record: pathlib.Path, runner:
         "--kernel", platform.release(), "--module-version", resolved["version"],
         *route_args, "--live-output", "0", "--install", "--evidence-directory", str(evidence),
     ]
-    runner.run(command, cwd=source)
+    runner.run(command, cwd=source, passthrough=True)
     result = verify_development_result(evidence / "rendered-source" / "DEVELOPMENT_MANIFEST.json", resolved)
     after = existing_inventory(pathlib.Path("/"), runner)
     require(not after["activeModule"], "RP1 GPCLK module became active during development installation")
@@ -1030,10 +1055,12 @@ def parser() -> argparse.ArgumentParser:
     prepare_parser.add_argument("--model-file", type=pathlib.Path, default=pathlib.Path("/proc/device-tree/model"))
     prepare_parser.add_argument("--compatible-file", type=pathlib.Path, default=pathlib.Path("/proc/device-tree/compatible"))
     prepare_parser.add_argument("--dry-run", action="store_true")
+    prepare_parser.add_argument("--debug", action="store_true")
     apply_parser = sub.add_parser("apply")
     apply_parser.add_argument("--state-dir", type=pathlib.Path, required=True)
     apply_parser.add_argument("--record", type=pathlib.Path, default=pathlib.Path("/var/lib/wsprrypi/rp1-gpclk-dkms-installation.json"))
     apply_parser.add_argument("--root", type=pathlib.Path, default=pathlib.Path("/"))
+    apply_parser.add_argument("--debug", action="store_true")
     return result
 
 
@@ -1041,9 +1068,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser().parse_args(argv)
     try:
         if args.command == "prepare":
-            prepare(args, Runner())
+            prepare(args, Runner(args.debug))
         else:
-            apply(args, Runner())
+            apply(args, Runner(args.debug))
     except ContractError as error:
         print(f"RP1-GPCLK-DKMS installation refused: {error}", file=sys.stderr)
         return 1

--- a/scripts/rp1_gpclk_dkms_install.py
+++ b/scripts/rp1_gpclk_dkms_install.py
@@ -1,0 +1,1054 @@
+#!/usr/bin/env python3
+"""Resolve and install the independently owned RP1-GPCLK-DKMS provider.
+
+This helper deliberately owns only WsprryPi's orchestration and acceptance
+policy.  Package and exact-source lifecycle mechanics remain upstream.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import platform
+import re
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+
+REPOSITORY = "WsprryPi/RP1-GPCLK-DKMS"
+REPOSITORY_URL = "https://github.com/WsprryPi/RP1-GPCLK-DKMS.git"
+API_BASE = f"https://api.github.com/repos/{REPOSITORY}"
+MANIFEST_NAME = "rp1-gpclk-dkms-installation-manifest-v1.json"
+CHECKSUMS_NAME = "SHA256SUMS"
+MANIFEST_SCHEMA = "rp1-gpclk-dkms-installation-manifest-v1"
+ADMIN_PROTOCOL = "rp1-gpclk-route-manager-v1"
+PACKAGE_NAME = "rp1-gpclk-dkms"
+DKMS_NAME = "rp1-gpclk-dkms"
+MODULE_NAME = "rp1_gpclk_dkms"
+COMPATIBILITY_IDENTITY = "v0.9.0-pi5"
+RECORD_SCHEMA = "wsprrypi-rp1-gpclk-dkms-installation-v1"
+STATE_SCHEMA = "wsprrypi-rp1-gpclk-dkms-plan-v1"
+SUPPORTED_UAPI_MIN = 4
+SUPPORTED_UAPI_MAX = 4
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+SEMVER = re.compile(r"^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+SAFE_VERSION = re.compile(r"^[0-9A-Za-z.+:~-]+$")
+MAX_API_BYTES = 16 * 1024 * 1024
+MAX_METADATA_BYTES = 2 * 1024 * 1024
+MAX_PACKAGE_BYTES = 256 * 1024 * 1024
+MAX_PACKAGE_MEMBERS = 20000
+MAX_PACKAGE_MEMBER_BYTES = 64 * 1024 * 1024
+MAX_EXPANDED_TAR_BYTES = 512 * 1024 * 1024
+MAX_ARCHIVE_PATH_BYTES = 1024
+
+
+class ContractError(RuntimeError):
+    """A fail-closed contract refusal."""
+
+
+def canonical(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ContractError(message)
+
+
+def require_exact_keys(value: Mapping[str, Any], required: Iterable[str], where: str) -> None:
+    required_set = set(required)
+    missing = sorted(required_set - set(value))
+    require(not missing, f"{where} is missing required fields: {', '.join(missing)}")
+    unexpected = sorted(set(value) - required_set)
+    require(not unexpected, f"{where} contains unsupported fields: {', '.join(unexpected)}")
+
+
+def parse_semver(tag: str) -> tuple[int, int, int]:
+    match = SEMVER.fullmatch(tag)
+    if not match:
+        raise ContractError(f"release tag is not an immutable semantic version: {tag!r}")
+    return tuple(int(match.group(index)) for index in range(1, 4))
+
+
+def normalize_repository_url(url: str) -> str:
+    if url in {
+        REPOSITORY_URL,
+        "https://github.com/WsprryPi/RP1-GPCLK-DKMS",
+        "git@github.com:WsprryPi/RP1-GPCLK-DKMS.git",
+        "ssh://git@github.com/WsprryPi/RP1-GPCLK-DKMS.git",
+    }:
+        return REPOSITORY_URL
+    return url
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    stdout: str
+    stderr: str
+    returncode: int
+
+
+class Runner:
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        check: bool = True,
+        cwd: pathlib.Path | None = None,
+    ) -> CommandResult:
+        try:
+            process = subprocess.run(
+                list(argv),
+                cwd=cwd,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+        except FileNotFoundError as error:
+            result = CommandResult("", f"required command is unavailable: {argv[0]}", 127)
+            if check:
+                raise ContractError(result.stderr) from error
+            return result
+        result = CommandResult(process.stdout, process.stderr, process.returncode)
+        if check and process.returncode:
+            detail = process.stderr.strip() or process.stdout.strip() or "no diagnostic"
+            raise ContractError(f"command failed ({argv[0]}): {detail}")
+        return result
+
+
+def read_device_tree_text(path: pathlib.Path) -> list[str]:
+    try:
+        return [item.decode("utf-8", "strict") for item in path.read_bytes().split(b"\0") if item]
+    except (OSError, UnicodeError):
+        return []
+
+
+def detect_platform(model_file: pathlib.Path, compatible_file: pathlib.Path) -> dict[str, Any]:
+    models = read_device_tree_text(model_file)
+    compatibles = read_device_tree_text(compatible_file)
+    model = models[0] if models else "unknown"
+    pi5_model = bool(
+        re.fullmatch(r"Raspberry Pi 5(?: Model B)?(?: Rev .+)?", model)
+        or re.fullmatch(r"Raspberry Pi Compute Module 5(?: Rev .+)?", model)
+    )
+    pi5_compatible = any(
+        item in {"raspberrypi,5-model-b", "raspberrypi,5-compute-module"}
+        for item in compatibles
+    )
+    bcm2712 = any(item in {"brcm,bcm2712", "brcm,bcm2712d0"} for item in compatibles)
+    positive = pi5_model and pi5_compatible and bcm2712
+    return {
+        "model": model,
+        "compatible": compatibles,
+        "classification": "raspberry-pi-5-family" if positive else "other-or-unknown",
+        "automaticEligible": positive,
+    }
+
+
+def installation_decision(requested: str, detected: Mapping[str, Any]) -> dict[str, Any]:
+    require(requested in {"auto", "true", "false"}, "INSTALL_RP1_GPCLK_DKMS must be auto, true, or false")
+    eligible = detected.get("automaticEligible") is True
+    if requested == "false":
+        return {"install": False, "reason": "explicit operator opt-out", "platformOverride": False}
+    if requested == "true":
+        return {
+            "install": True,
+            "reason": "explicit operator installation request",
+            "platformOverride": not eligible,
+        }
+    return {
+        "install": eligible,
+        "reason": "positively identified Raspberry Pi 5-family system" if eligible else "automatic selection skipped other or unknown system",
+        "platformOverride": False,
+    }
+
+
+def wsprry_channel(source: str) -> str:
+    require(bool(source) and source not in {"HEAD", "detached", "unknown"}, "WsprryPi source channel is ambiguous; set RP1_GPCLK_DKMS_SOURCE explicitly")
+    if source in {"main", "master", "release"} or SEMVER.fullmatch(source):
+        return "production"
+    require(re.fullmatch(r"[A-Za-z0-9._/-]+", source) is not None, "WsprryPi source channel contains unsupported characters")
+    return "development"
+
+
+def source_selector(requested: str, channel: str) -> tuple[str, str | None]:
+    if requested == "auto":
+        return ("release", None) if channel == "production" else ("devel", None)
+    if requested in {"release", "devel"}:
+        return requested, None
+    if requested.startswith("commit:"):
+        commit = requested.removeprefix("commit:")
+        require(SHA40.fullmatch(commit) is not None, "commit source requires a full lowercase 40-character SHA")
+        return "commit", commit
+    if requested.startswith("checkout:"):
+        path = requested.removeprefix("checkout:")
+        require(pathlib.Path(path).is_absolute(), "checkout source requires an absolute path")
+        return "checkout", path
+    raise ContractError("RP1_GPCLK_DKMS_SOURCE must be auto, release, devel, commit:FULL_SHA, or checkout:/absolute/path")
+
+
+def release_assets(release: Mapping[str, Any]) -> dict[str, str]:
+    assets: dict[str, str] = {}
+    for asset in release.get("assets", []):
+        if not isinstance(asset, dict):
+            continue
+        name, url = asset.get("name"), asset.get("browser_download_url")
+        if isinstance(name, str) and isinstance(url, str) and asset.get("state") == "uploaded":
+            require(name not in assets, f"release contains duplicate asset name: {name}")
+            assets[name] = url
+    return assets
+
+
+def release_candidate(release: Mapping[str, Any]) -> bool:
+    if release.get("draft") is not False or release.get("prerelease") is not False:
+        return False
+    if release.get("immutable") is not True:
+        return False
+    if not isinstance(release.get("published_at"), str) or not release.get("published_at"):
+        return False
+    tag = release.get("tag_name")
+    if not isinstance(tag, str) or SEMVER.fullmatch(tag) is None:
+        return False
+    assets = release_assets(release)
+    return MANIFEST_NAME in assets and CHECKSUMS_NAME in assets and any(
+        re.fullmatch(r"rp1-gpclk-dkms_[0-9A-Za-z.+:~-]+_all\.deb", name) for name in assets
+    )
+
+
+def select_release(releases: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
+    candidates = [release for release in releases if release_candidate(release)]
+    require(bool(candidates), "no eligible RP1-GPCLK-DKMS release is available")
+    return max(candidates, key=lambda item: parse_semver(str(item["tag_name"])))
+
+
+def authoritative_asset_url(tag: str, filename: str, url: str) -> None:
+    parsed = urllib.parse.urlsplit(url)
+    require(parsed.scheme == "https" and parsed.netloc == "github.com", f"release asset URL is not authoritative HTTPS: {url}")
+    expected = f"/{REPOSITORY}/releases/download/{urllib.parse.quote(tag, safe='')}/{urllib.parse.quote(filename, safe='._+-~') }"
+    require(parsed.path == expected and not parsed.query and not parsed.fragment, f"release asset URL does not match repository, tag, and filename: {url}")
+
+
+def parse_checksums(data: bytes) -> dict[str, str]:
+    try:
+        text = data.decode("ascii")
+    except UnicodeError as error:
+        raise ContractError("SHA256SUMS is not ASCII") from error
+    result: dict[str, str] = {}
+    for line in text.splitlines():
+        if not line:
+            continue
+        match = re.fullmatch(r"([0-9a-f]{64})  ([A-Za-z0-9][A-Za-z0-9._+:~-]*)", line)
+        require(match is not None, "SHA256SUMS contains a malformed or unsafe line")
+        digest, filename = match.groups()
+        require(filename not in result, f"SHA256SUMS repeats {filename}")
+        result[filename] = digest
+    return result
+
+
+def validate_manifest(manifest: Any, *, tag: str, tag_commit: str) -> dict[str, Any]:
+    require(isinstance(manifest, dict), "installation manifest must be a JSON object")
+    required = {
+        "schema", "schemaVersion", "repository", "releaseTag", "sourceCommit",
+        "productVersion", "debianVersion", "package", "dkmsModule", "kernelModule",
+        "uapi", "administrationProtocol", "packageInventory", "packageInventorySha256",
+        "installationBehavior", "releaseChannel",
+    }
+    require_exact_keys(manifest, required, "installation manifest")
+    require(manifest["schema"] == MANIFEST_SCHEMA and manifest["schemaVersion"] == 1, "unsupported installation manifest schema")
+    require(manifest["repository"] == REPOSITORY, "installation manifest repository substitution")
+    require(manifest["releaseTag"] == tag, "manifest release tag differs from selected release")
+    require(manifest["sourceCommit"] == tag_commit and SHA40.fullmatch(tag_commit) is not None, "manifest source commit differs from immutable tag commit")
+    version = tag.removeprefix("v")
+    require(manifest["productVersion"] == version, "manifest product version differs from release tag")
+    require(isinstance(manifest["debianVersion"], str) and SAFE_VERSION.fullmatch(manifest["debianVersion"]), "manifest Debian version is invalid")
+    require(manifest["dkmsModule"] == DKMS_NAME and manifest["kernelModule"] == MODULE_NAME, "manifest module identity is incompatible")
+    require(manifest["administrationProtocol"] == ADMIN_PROTOCOL, "manifest administration protocol is incompatible")
+    require(manifest["releaseChannel"] == "release", "manifest is not classified for the release channel")
+    behavior = manifest["installationBehavior"]
+    require(isinstance(behavior, dict), "manifest installation behavior must be an object")
+    require_exact_keys(
+        behavior,
+        {"routeNeutral", "outputDisabled", "loadsModule", "appliesOverlay", "editsBootConfiguration", "operatesServices"},
+        "manifest installation behavior",
+    )
+    require(
+        behavior == {
+            "routeNeutral": True,
+            "outputDisabled": True,
+            "loadsModule": False,
+            "appliesOverlay": False,
+            "editsBootConfiguration": False,
+            "operatesServices": False,
+        },
+        "manifest does not declare the required inactive installation behavior",
+    )
+    package = manifest["package"]
+    require(isinstance(package, dict), "manifest package must be an object")
+    require_exact_keys(package, {"name", "filename", "sha256"}, "manifest package")
+    require(package["name"] == PACKAGE_NAME, "manifest package name is incompatible")
+    expected_filename = f"{PACKAGE_NAME}_{manifest['debianVersion']}_all.deb"
+    require(package["filename"] == expected_filename, "manifest package filename and Debian version differ")
+    require(isinstance(package["sha256"], str) and SHA256.fullmatch(package["sha256"]), "manifest package SHA-256 is invalid")
+    uapi = manifest["uapi"]
+    require(isinstance(uapi, dict), "manifest UAPI must be an object")
+    require_exact_keys(uapi, {"abiMin", "abiMax", "sha256", "path"}, "manifest UAPI")
+    require(isinstance(uapi["abiMin"], int) and isinstance(uapi["abiMax"], int), "manifest UAPI ABI range is invalid")
+    require(uapi["abiMin"] <= SUPPORTED_UAPI_MAX and uapi["abiMax"] >= SUPPORTED_UAPI_MIN, "manifest UAPI ABI is not supported by this WsprryPi consumer")
+    require(isinstance(uapi["sha256"], str) and SHA256.fullmatch(uapi["sha256"]), "manifest UAPI SHA-256 is invalid")
+    require(isinstance(uapi["path"], str) and safe_archive_path(uapi["path"]), "manifest UAPI path is unsafe")
+    inventory = manifest["packageInventory"]
+    require(isinstance(inventory, list) and bool(inventory), "manifest package inventory is empty or invalid")
+    normalized = validate_inventory(inventory)
+    require(isinstance(manifest["packageInventorySha256"], str) and SHA256.fullmatch(manifest["packageInventorySha256"]), "manifest package inventory SHA-256 is invalid")
+    require(sha256_bytes(canonical(normalized)) == manifest["packageInventorySha256"], "manifest package inventory hash is inconsistent")
+    matches = [item for item in normalized if item["path"] == uapi["path"]]
+    require(len(matches) == 1 and matches[0]["type"] == "file" and matches[0]["sha256"] == uapi["sha256"], "manifest UAPI is not bound to the package inventory")
+    result = dict(manifest)
+    result["packageInventory"] = normalized
+    return result
+
+
+def safe_archive_path(value: str) -> bool:
+    if not value or "\0" in value or value.startswith("/"):
+        return False
+    parts = pathlib.PurePosixPath(value).parts
+    return all(part not in {"", ".", ".."} for part in parts)
+
+
+def validate_inventory(inventory: Sequence[Any]) -> list[dict[str, Any]]:
+    require(len(inventory) <= MAX_PACKAGE_MEMBERS, "package inventory exceeds the bounded member limit")
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in inventory:
+        require(isinstance(raw, dict), "package inventory member must be an object")
+        require_exact_keys(raw, {"path", "type", "mode", "sha256"}, "package inventory member")
+        path, kind, mode, digest = raw["path"], raw["type"], raw["mode"], raw["sha256"]
+        require(isinstance(path, str) and len(path.encode("utf-8")) <= MAX_ARCHIVE_PATH_BYTES, "package inventory path exceeds the bounded length")
+        require(isinstance(path, str) and safe_archive_path(path), "package inventory contains an unsafe path")
+        require(path not in seen, f"package inventory repeats path: {path}")
+        require(kind in {"file", "directory", "symlink"}, f"package inventory contains unsupported type: {kind!r}")
+        require(isinstance(mode, str) and re.fullmatch(r"0[0-7]{3}", mode) is not None, "package inventory mode is invalid")
+        require(isinstance(digest, str) and SHA256.fullmatch(digest) is not None, "package inventory SHA-256 is invalid")
+        seen.add(path)
+        result.append({"path": path, "type": kind, "mode": mode, "sha256": digest})
+    return sorted(result, key=lambda item: item["path"])
+
+
+def tar_inventory(tar_path: pathlib.Path) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    try:
+        archive = tarfile.open(tar_path, "r:*")
+    except (tarfile.TarError, OSError) as error:
+        raise ContractError("Debian data archive is unreadable or uses unsupported compression") from error
+    with archive:
+        for member_index, member in enumerate(archive, start=1):
+            require(member_index <= MAX_PACKAGE_MEMBERS, "package inventory exceeds the bounded member limit")
+            path = member.name.removeprefix("./")
+            if not path or path == ".":
+                continue
+            require(safe_archive_path(path), f"package contains unsafe archive path: {member.name!r}")
+            require(len(path.encode("utf-8")) <= MAX_ARCHIVE_PATH_BYTES, f"package path exceeds the bounded length: {path!r}")
+            require(path not in seen, f"package repeats archive path: {path}")
+            seen.add(path)
+            mode = f"0{stat.S_IMODE(member.mode):03o}"
+            if member.isfile():
+                require(0 <= member.size <= MAX_PACKAGE_MEMBER_BYTES, f"package member exceeds the bounded size limit: {path}")
+                stream = archive.extractfile(member)
+                require(stream is not None, f"package member cannot be read: {path}")
+                digest = hashlib.sha256(stream.read()).hexdigest()
+                kind = "file"
+            elif member.isdir():
+                digest = sha256_bytes(b"")
+                kind = "directory"
+            elif member.issym():
+                require(not member.linkname.startswith("/"), f"package symlink has an absolute target: {path}")
+                target_parts = pathlib.PurePosixPath(path).parent.joinpath(member.linkname).parts
+                depth = 0
+                for part in target_parts:
+                    if part == "..":
+                        depth -= 1
+                    elif part not in {"", "."}:
+                        depth += 1
+                    require(depth >= 0, f"package symlink escapes package root: {path}")
+                digest = sha256_bytes(member.linkname.encode())
+                kind = "symlink"
+            else:
+                raise ContractError(f"package contains unsupported special or hard-linked member: {path}")
+            result.append({"path": path, "type": kind, "mode": mode, "sha256": digest})
+    return sorted(result, key=lambda item: item["path"])
+
+
+def parse_debian_control(text: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    current: str | None = None
+    for line in text.splitlines():
+        if line.startswith((" ", "\t")):
+            require(current is not None, "Debian control continuation has no field")
+            fields[current] += "\n" + line[1:]
+            continue
+        if not line:
+            continue
+        require(":" in line, "Debian control contains malformed field")
+        key, value = line.split(":", 1)
+        require(re.fullmatch(r"[A-Za-z0-9-]+", key) is not None and key not in fields, "Debian control contains invalid or duplicate field")
+        fields[key] = value.strip()
+        current = key
+    return fields
+
+
+def validate_package(path: pathlib.Path, manifest: Mapping[str, Any], runner: Runner) -> None:
+    package = manifest["package"]
+    require(path.name == package["filename"], "downloaded package filename differs from manifest")
+    require(sha256_file(path) == package["sha256"], "downloaded package SHA-256 differs from manifest")
+    control = [
+        runner.run(["dpkg-deb", "-f", str(path), field]).stdout.strip()
+        for field in ("Package", "Version", "Architecture")
+    ]
+    require(control == [PACKAGE_NAME, manifest["debianVersion"], "all"], "Debian control identity differs from manifest")
+    tar_path = path.parent / "data.tar"
+    process = subprocess.Popen(
+        ["dpkg-deb", "--fsys-tarfile", str(path)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    expanded = 0
+    with tar_path.open("wb") as stream:
+        assert process.stdout is not None
+        for chunk in iter(lambda: process.stdout.read(1024 * 1024), b""):
+            expanded += len(chunk)
+            if expanded > MAX_EXPANDED_TAR_BYTES:
+                process.kill()
+                process.wait()
+                tar_path.unlink(missing_ok=True)
+                raise ContractError("Debian data archive exceeds the bounded expanded size limit")
+            stream.write(chunk)
+    assert process.stderr is not None
+    stderr = process.stderr.read().decode(errors="replace").strip()
+    returncode = process.wait()
+    require(returncode == 0, f"dpkg-deb could not expose package inventory: {stderr}")
+    try:
+        actual = tar_inventory(tar_path)
+    finally:
+        tar_path.unlink(missing_ok=True)
+    require(actual == manifest["packageInventory"], "package contents differ from checksummed manifest inventory")
+
+
+class GitHubClient:
+    def __init__(self, token: str | None = None):
+        self.headers = {"Accept": "application/vnd.github+json", "User-Agent": "WsprryPi-installer"}
+        if token:
+            self.headers["Authorization"] = f"Bearer {token}"
+
+    def bytes(self, url: str, *, limit: int = MAX_API_BYTES, allow_asset_redirect: bool = False) -> bytes:
+        headers = self.headers if not allow_asset_redirect else {
+            "Accept": "application/octet-stream", "User-Agent": "WsprryPi-installer"
+        }
+        request = urllib.request.Request(url, headers=headers, method="GET")
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                final = response.geturl()
+                if final != url:
+                    parsed = urllib.parse.urlsplit(final)
+                    require(
+                        allow_asset_redirect
+                        and parsed.scheme == "https"
+                        and parsed.netloc in {"release-assets.githubusercontent.com", "objects.githubusercontent.com"},
+                        f"unexpected redirect while retrieving {url}",
+                    )
+                length = response.headers.get("Content-Length")
+                if length is not None:
+                    require(length.isdigit() and int(length) <= limit, f"remote content exceeds the bounded size limit: {url}")
+                data = response.read(limit + 1)
+                require(len(data) <= limit, f"remote content exceeds the bounded size limit: {url}")
+                return data
+        except (urllib.error.URLError, TimeoutError) as error:
+            raise ContractError(f"failed to retrieve {url}: {error}") from error
+
+    def json(self, url: str) -> Any:
+        try:
+            return json.loads(self.bytes(url, limit=MAX_API_BYTES))
+        except json.JSONDecodeError as error:
+            raise ContractError(f"remote JSON is malformed: {url}") from error
+
+    def releases(self) -> list[Mapping[str, Any]]:
+        result: list[Mapping[str, Any]] = []
+        for page in range(1, 21):
+            payload = self.json(f"{API_BASE}/releases?per_page=100&page={page}")
+            require(isinstance(payload, list), "GitHub releases response is not an array")
+            result.extend(item for item in payload if isinstance(item, dict))
+            if len(payload) < 100:
+                return result
+        raise ContractError("GitHub release enumeration exceeded the bounded page limit")
+
+    def tag_commit(self, tag: str) -> str:
+        payload = self.json(f"{API_BASE}/git/ref/tags/{urllib.parse.quote(tag, safe='')}")
+        require(isinstance(payload, dict) and isinstance(payload.get("object"), dict), "Git tag reference response is malformed")
+        obj = payload["object"]
+        for _ in range(8):
+            kind, sha = obj.get("type"), obj.get("sha")
+            require(isinstance(sha, str) and SHA40.fullmatch(sha), "Git tag object SHA is malformed")
+            if kind == "commit":
+                return sha
+            require(kind == "tag", "Git tag does not resolve to a commit")
+            annotated = self.json(f"{API_BASE}/git/tags/{sha}")
+            require(isinstance(annotated, dict) and isinstance(annotated.get("object"), dict), "annotated Git tag response is malformed")
+            obj = annotated["object"]
+        raise ContractError("Git tag indirection exceeds the bounded resolution limit")
+
+
+def download_release(state_dir: pathlib.Path, client: GitHubClient, runner: Runner) -> dict[str, Any]:
+    release = select_release(client.releases())
+    tag = str(release["tag_name"])
+    assets = release_assets(release)
+    package_names = sorted(name for name in assets if re.fullmatch(r"rp1-gpclk-dkms_[0-9A-Za-z.+:~-]+_all\.deb", name))
+    require(len(package_names) == 1, "selected release must contain exactly one RP1-GPCLK-DKMS package")
+    package_name = package_names[0]
+    for name in (MANIFEST_NAME, CHECKSUMS_NAME, package_name):
+        authoritative_asset_url(tag, name, assets[name])
+    manifest_bytes = client.bytes(assets[MANIFEST_NAME], limit=MAX_METADATA_BYTES, allow_asset_redirect=True)
+    checksums_bytes = client.bytes(assets[CHECKSUMS_NAME], limit=MAX_METADATA_BYTES, allow_asset_redirect=True)
+    asset_objects = {
+        item["name"]: item for item in release.get("assets", [])
+        if isinstance(item, dict) and isinstance(item.get("name"), str)
+    }
+    for name, data in ((MANIFEST_NAME, manifest_bytes), (CHECKSUMS_NAME, checksums_bytes)):
+        api_digest = asset_objects[name].get("digest")
+        if api_digest is not None:
+            require(api_digest == f"sha256:{sha256_bytes(data)}", f"GitHub asset digest differs for {name}")
+    checksums = parse_checksums(checksums_bytes)
+    require(checksums.get(MANIFEST_NAME) == sha256_bytes(manifest_bytes), "SHA256SUMS does not bind the installation manifest")
+    try:
+        manifest_raw = json.loads(manifest_bytes)
+    except json.JSONDecodeError as error:
+        raise ContractError("selected release installation manifest is malformed") from error
+    tag_commit = client.tag_commit(tag)
+    manifest = validate_manifest(manifest_raw, tag=tag, tag_commit=tag_commit)
+    require(manifest["package"]["filename"] == package_name, "selected package asset differs from manifest")
+    require(checksums.get(package_name) == manifest["package"]["sha256"], "SHA256SUMS package identity differs from manifest")
+    package_path = state_dir / package_name
+    package_bytes = client.bytes(assets[package_name], limit=MAX_PACKAGE_BYTES, allow_asset_redirect=True)
+    api_package_digest = asset_objects[package_name].get("digest")
+    if api_package_digest is not None:
+        require(api_package_digest == f"sha256:{sha256_bytes(package_bytes)}", "GitHub asset digest differs for the package")
+    package_path.write_bytes(package_bytes)
+    os.chmod(package_path, 0o600)
+    validate_package(package_path, manifest, runner)
+    (state_dir / MANIFEST_NAME).write_bytes(canonical(manifest) + b"\n")
+    os.chmod(state_dir / MANIFEST_NAME, 0o600)
+    return {"channel": "release", "tag": tag, "commit": tag_commit, "manifest": manifest, "packagePath": str(package_path)}
+
+
+def git_output(runner: Runner, source: pathlib.Path, *args: str) -> str:
+    return runner.run(["git", "-C", str(source), *args]).stdout.strip()
+
+
+def validate_checkout(source_text: str, runner: Runner) -> dict[str, Any]:
+    requested = pathlib.Path(source_text)
+    require(requested.is_absolute(), "checkout source requires an absolute path")
+    require(requested.exists() and requested.is_dir(), "checkout source is not an existing directory")
+    absolute = pathlib.Path(os.path.abspath(requested))
+    resolved = requested.resolve(strict=True)
+    require(absolute == resolved, "checkout source contains a symlink or path substitution")
+    top = pathlib.Path(git_output(runner, resolved, "rev-parse", "--show-toplevel"))
+    require(top.resolve(strict=True) == resolved, "checkout path is not the repository root")
+    remote = git_output(runner, resolved, "remote", "get-url", "origin")
+    require(normalize_repository_url(remote) == REPOSITORY_URL, "checkout is not the authoritative RP1-GPCLK-DKMS repository")
+    commit = git_output(runner, resolved, "rev-parse", "HEAD")
+    require(SHA40.fullmatch(commit) is not None, "checkout HEAD is not a full commit SHA")
+    status_text = git_output(runner, resolved, "status", "--porcelain=v1", "--untracked-files=all")
+    require(not status_text, "checkout has tracked or untracked changes")
+    flags = git_output(runner, resolved, "ls-files", "-v").splitlines()
+    require(all(line.startswith("H ") for line in flags), "checkout uses assume-unchanged, skip-worktree, or unsupported tracked-file state")
+    tree = git_output(runner, resolved, "rev-parse", "HEAD^{tree}")
+    require(SHA40.fullmatch(tree) is not None, "checkout tree identity is invalid")
+    root_stat, git_stat = resolved.stat(), pathlib.Path(git_output(runner, resolved, "rev-parse", "--absolute-git-dir")).resolve(strict=True).stat()
+    return {
+        "path": str(resolved), "commit": commit, "tree": tree,
+        "rootDevice": root_stat.st_dev, "rootInode": root_stat.st_ino,
+        "gitDevice": git_stat.st_dev, "gitInode": git_stat.st_ino,
+    }
+
+
+def clone_exact(state_dir: pathlib.Path, selector: str, value: str | None, runner: Runner) -> dict[str, Any]:
+    source = state_dir / "source"
+    runner.run(["git", "clone", "--no-checkout", "--origin", "origin", REPOSITORY_URL, str(source)])
+    if selector == "devel":
+        result = runner.run(["git", "-C", str(source), "rev-parse", "--verify", "origin/devel^{commit}"], check=False)
+        require(result.returncode == 0, "authoritative RP1-GPCLK-DKMS origin/devel is unavailable")
+        commit = result.stdout.strip()
+    else:
+        require(value is not None and SHA40.fullmatch(value) is not None, "internal exact-commit resolution error")
+        result = runner.run(["git", "-C", str(source), "cat-file", "-e", f"{value}^{{commit}}"], check=False)
+        require(result.returncode == 0, "requested RP1-GPCLK-DKMS commit does not exist in the authoritative repository")
+        commit = value
+    require(SHA40.fullmatch(commit) is not None, "resolved development commit is not immutable")
+    runner.run(["git", "-C", str(source), "checkout", "--detach", commit])
+    identity = validate_checkout(str(source), runner)
+    require(identity["commit"] == commit, "development checkout changed after immutable resolution")
+    return identity
+
+
+def development_version(source: pathlib.Path) -> str:
+    model = source / "release" / "installation-model-v1.json"
+    try:
+        payload = json.loads(model.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ContractError("development source lacks a readable upstream installation model") from error
+    version = payload.get("release")
+    require(isinstance(version, str) and SAFE_VERSION.fullmatch(version), "development source installation model has an invalid version")
+    return version
+
+
+def route_neutral_interface(source: pathlib.Path, runner: Runner) -> tuple[str, list[str]]:
+    installer = source / "scripts" / "development-install"
+    preflight = source / "scripts" / "development-preflight"
+    require(installer.is_file() and os.access(installer, os.X_OK) and preflight.is_file() and os.access(preflight, os.X_OK), "development source lacks maintained executable lifecycle tools")
+    help_result = runner.run([str(installer), "--help"], cwd=source)
+    help_text = help_result.stdout + help_result.stderr
+    if "--route-neutral" in help_text:
+        return "route-neutral-flag", ["--route-neutral"]
+    if re.search(r"--route[^\n]*route-neutral", help_text):
+        return "route-choice", ["--route", "route-neutral"]
+    raise ContractError("upstream development-install has no reviewed route-neutral installation interface; no development mutation was attempted")
+
+
+def revalidate_checkout(identity: Mapping[str, Any], runner: Runner) -> pathlib.Path:
+    source = pathlib.Path(str(identity["path"]))
+    try:
+        current = validate_checkout(str(source), runner)
+    except ContractError as error:
+        raise ContractError("development checkout was dirty or replaced after preflight") from error
+    for key in ("commit", "tree", "rootDevice", "rootInode", "gitDevice", "gitInode"):
+        require(current[key] == identity[key], "development checkout was dirty or replaced after preflight")
+    return source
+
+
+def prepare_development(state_dir: pathlib.Path, selector: str, value: str | None, runner: Runner) -> dict[str, Any]:
+    if selector == "checkout":
+        original = validate_checkout(str(value), runner)
+        snapshot = state_dir / "source"
+        runner.run(["git", "clone", "--no-local", "--no-checkout", original["path"], str(snapshot)])
+        runner.run(["git", "-C", str(snapshot), "remote", "set-url", "origin", REPOSITORY_URL])
+        runner.run(["git", "-C", str(snapshot), "checkout", "--detach", original["commit"]])
+        identity = validate_checkout(str(snapshot), runner)
+        require(
+            identity["commit"] == original["commit"] and identity["tree"] == original["tree"],
+            "local checkout snapshot differs from the selected commit",
+        )
+    else:
+        identity = clone_exact(state_dir, selector, value, runner)
+    source = pathlib.Path(identity["path"])
+    version = development_version(source)
+    uapi = source / "include" / "uapi" / "linux" / "rp1_gpclk.h"
+    require(uapi.is_file() and not uapi.is_symlink(), "development source lacks the canonical regular-file UAPI")
+    interface, route_args = route_neutral_interface(source, runner)
+    runner.run([str(source / "scripts" / "development-preflight"), "--kernel", platform.release()], cwd=source)
+    return {
+        "channel": "development", "commit": identity["commit"], "version": version,
+        "checkout": identity, "interface": interface, "routeArguments": route_args,
+        "sourceTree": identity["tree"], "uapiSha256": sha256_file(uapi),
+        "compatibilityIdentity": COMPATIBILITY_IDENTITY,
+    }
+
+
+def secure_state_dir(path: pathlib.Path) -> pathlib.Path:
+    require(path.is_absolute() and path.exists() and path.is_dir(), "state directory must be an existing absolute directory")
+    resolved = path.resolve(strict=True)
+    require(resolved == pathlib.Path(os.path.abspath(path)), "state directory cannot contain symlinks")
+    info = resolved.stat()
+    require(info.st_uid == os.geteuid(), "state directory is not owned by the invoking user")
+    require(stat.S_IMODE(info.st_mode) & 0o077 == 0, "state directory must not be accessible by group or others")
+    return resolved
+
+
+def secure_record_parent(path: pathlib.Path) -> None:
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    absolute = pathlib.Path(os.path.abspath(parent))
+    resolved = parent.resolve(strict=True)
+    require(absolute == resolved, "installation record parent contains a symlink or path substitution")
+    info = resolved.stat()
+    require(info.st_uid == os.geteuid(), "installation record parent is not owned by the invoking user")
+    require(stat.S_IMODE(info.st_mode) & 0o022 == 0, "installation record parent is group- or world-writable")
+
+
+def atomic_json(path: pathlib.Path, value: Any, mode: int = 0o600) -> None:
+    payload = canonical(value) + b"\n"
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.fchmod(descriptor, mode)
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def render_plan(plan: Mapping[str, Any]) -> None:
+    print("RP1-GPCLK-DKMS installation plan")
+    print(f"  WsprryPi source channel: {plan['wsprryChannel']}")
+    print(f"  Installation decision: {'install' if plan['decision']['install'] else 'skip'} ({plan['decision']['reason']})")
+    print(f"  Detected platform: {plan['platform']['model']} [{plan['platform']['classification']}]")
+    print(f"  Explicit platform override: {'yes' if plan['decision']['platformOverride'] else 'no'}")
+    print(f"  Requested source selector: {plan['requestedSource']}")
+    if plan.get("resolved"):
+        resolved = plan["resolved"]
+        print(f"  Resolved channel: {resolved['channel']}")
+        print(f"  Resolved tag or commit: {resolved.get('tag') or resolved.get('commit')}")
+        if resolved["channel"] == "release":
+            manifest = resolved["manifest"]
+            print(f"  Product/Debian version: {manifest['productVersion']} / {manifest['debianVersion']}")
+            print(f"  Package SHA-256: {manifest['package']['sha256']}")
+            print(f"  UAPI SHA-256: {manifest['uapi']['sha256']}")
+            print("  Planned lifecycle: apt-get install of the validated local Debian package")
+        else:
+            print(f"  Source version: {resolved['version']}")
+            print(f"  Source tree: {resolved['sourceTree']}")
+            print(f"  UAPI SHA-256: {resolved['uapiSha256']}")
+            print("  Module SHA-256: resolved and verified by the upstream exact-source build")
+            print("  Planned lifecycle: upstream development-preflight and exact-source development-install")
+    print("  Safety boundary: route activation and output remain disabled; no overlay, module load, service, GPIO, or RF action is authorized.")
+
+
+def prepare(args: argparse.Namespace, runner: Runner) -> dict[str, Any]:
+    state_dir = secure_state_dir(args.state_dir)
+    detected = detect_platform(args.model_file, args.compatible_file)
+    decision = installation_decision(args.install, detected)
+    explicit_source = args.source != "auto"
+    try:
+        channel = wsprry_channel(args.wsprry_source)
+    except ContractError:
+        if not explicit_source:
+            raise
+        channel = "explicit-source"
+    plan: dict[str, Any] = {
+        "schema": STATE_SCHEMA, "wsprrySource": args.wsprry_source, "wsprryChannel": channel,
+        "platform": detected, "decision": decision, "requestedSource": args.source,
+        "resolved": None, "dryRun": args.dry_run,
+    }
+    if decision["install"]:
+        selector, value = source_selector(args.source, channel)
+        if selector == "release":
+            plan["resolved"] = download_release(state_dir, GitHubClient(os.environ.get("GITHUB_TOKEN")), runner)
+        else:
+            plan["resolved"] = prepare_development(state_dir, selector, value, runner)
+    atomic_json(state_dir / "plan.json", plan)
+    render_plan(plan)
+    return plan
+
+
+def root_path(root: pathlib.Path, absolute: str) -> pathlib.Path:
+    require(absolute.startswith("/"), "internal installed path must be absolute")
+    return root / absolute.removeprefix("/")
+
+
+def existing_inventory(root: pathlib.Path, runner: Runner) -> dict[str, Any]:
+    package = runner.run(["dpkg-query", "-W", "-f=${Status}\n${Version}\n", PACKAGE_NAME], check=False)
+    package_version = None
+    if package.returncode == 0:
+        lines = package.stdout.splitlines()
+        require(len(lines) >= 2 and lines[0] == "install ok installed", "existing package state is ambiguous")
+        package_version = lines[1]
+    dkms = runner.run(["dkms", "status", "-m", DKMS_NAME], check=False)
+    modules_file = root_path(root, "/proc/modules")
+    active = False
+    if modules_file.exists():
+        active = any(line.split(maxsplit=1)[0] == MODULE_NAME for line in modules_file.read_text(errors="replace").splitlines() if line)
+    source_base = root_path(root, "/usr/src")
+    sources = sorted(str(path) for path in source_base.glob(f"{PACKAGE_NAME}-*") if source_base.exists())
+    module_candidates: list[str] = []
+    modules_base = root_path(root, "/lib/modules")
+    if modules_base.exists():
+        module_candidates = sorted(str(path) for path in modules_base.glob("*/updates/dkms/rp1_gpclk_dkms.ko*"))
+    enrollment = root_path(root, "/etc/rp1-gpclk-dkms/enrollment.json").exists()
+    manager = root_path(root, "/etc/systemd/system/rp1-gpclk-route-manager@.service.d/90-source-development.conf").exists()
+    overlay_paths = [
+        root_path(root, "/boot/firmware/overlays/rp1-gpclk-gpio4.dtbo"),
+        root_path(root, "/boot/firmware/overlays/rp1-gpclk-gpio20.dtbo"),
+        root_path(root, "/usr/lib/rp1-gpclk-dkms/overlays/rp1-gpclk-gpio4.dtbo"),
+        root_path(root, "/usr/lib/rp1-gpclk-dkms/overlays/rp1-gpclk-gpio20.dtbo"),
+    ]
+    overlays = sorted(str(path) for path in overlay_paths if path.exists() or path.is_symlink())
+    configured = False
+    for config in (root_path(root, "/boot/firmware/config.txt"), root_path(root, "/boot/config.txt")):
+        if config.is_file() and not config.is_symlink():
+            configured = configured or "dtoverlay=rp1-gpclk-" in config.read_text(errors="replace")
+    return {
+        "packageVersion": package_version, "dkms": dkms.stdout.strip(),
+        "activeModule": active, "sourceTrees": sources, "moduleCandidates": module_candidates,
+        "installedOverlays": overlays, "configuredRoute": configured,
+        "enrollment": enrollment, "developmentManager": manager,
+    }
+
+
+def installed_member(root: pathlib.Path, relative: str, expected_type: str) -> pathlib.Path:
+    current = root
+    parts = pathlib.PurePosixPath(relative).parts
+    for index, part in enumerate(parts):
+        current = current / part
+        try:
+            info = current.lstat()
+        except FileNotFoundError as error:
+            raise ContractError(f"installed package member is missing: /{relative}") from error
+        final = index == len(parts) - 1
+        if not final:
+            require(stat.S_ISDIR(info.st_mode) and not stat.S_ISLNK(info.st_mode), f"installed package path has a substituted ancestor: /{relative}")
+        elif expected_type == "file":
+            require(stat.S_ISREG(info.st_mode), f"installed package file is substituted: /{relative}")
+        elif expected_type == "directory":
+            require(stat.S_ISDIR(info.st_mode) and not stat.S_ISLNK(info.st_mode), f"installed package directory is substituted: /{relative}")
+        else:
+            require(stat.S_ISLNK(info.st_mode), f"installed package symlink is substituted: /{relative}")
+    return current
+
+
+def verify_installed_release(root: pathlib.Path, manifest: Mapping[str, Any], runner: Runner) -> None:
+    inventory = existing_inventory(root, runner)
+    require(inventory["packageVersion"] == manifest["debianVersion"], "installed Debian package version differs from plan")
+    require(not inventory["activeModule"], "RP1 GPCLK module became active during route-neutral installation")
+    require(not inventory["configuredRoute"], "RP1 GPCLK route became configured during route-neutral installation")
+    require(not inventory["enrollment"] and not inventory["developmentManager"], "installed provider has unexpected development enrollment or manager binding")
+    dkms_lines = [line for line in inventory["dkms"].splitlines() if line.strip()]
+    expected_dkms = re.compile(rf"^{re.escape(DKMS_NAME)}/{re.escape(manifest['productVersion'])}[^\n]*installed$")
+    require(bool(dkms_lines) and all(expected_dkms.fullmatch(line) for line in dkms_lines), "DKMS registration contains a missing, foreign, or non-installed version")
+
+    expected_sources: set[str] = set()
+    for member in manifest["packageInventory"]:
+        parts = pathlib.PurePosixPath(member["path"]).parts
+        if len(parts) >= 3 and parts[:2] == ("usr", "src") and parts[2].startswith(f"{PACKAGE_NAME}-"):
+            expected_sources.add(str(root_path(root, "/" + "/".join(parts[:3]))))
+    require(bool(expected_sources), "manifest package inventory does not contain the DKMS source destination")
+    require(set(inventory["sourceTrees"]) == expected_sources, "installed DKMS source destinations contain missing or foreign state")
+
+    expected_overlays = {
+        str(root_path(root, "/" + member["path"]))
+        for member in manifest["packageInventory"]
+        if member["path"].endswith(("/rp1-gpclk-gpio4.dtbo", "/rp1-gpclk-gpio20.dtbo"))
+    }
+    require(set(inventory["installedOverlays"]) == expected_overlays, "installed overlay inventory contains missing or foreign state")
+    for member in manifest["packageInventory"]:
+        installed = installed_member(root, member["path"], member["type"])
+        kind = member["type"]
+        if kind == "file":
+            require(sha256_file(installed) == member["sha256"], f"installed package file hash differs: /{member['path']}")
+        elif kind == "directory":
+            pass
+        else:
+            require(sha256_bytes(os.readlink(installed).encode()) == member["sha256"], f"installed package symlink differs: /{member['path']}")
+        if kind != "symlink":
+            actual_mode = f"0{stat.S_IMODE(installed.stat().st_mode):03o}"
+            require(actual_mode == member["mode"], f"installed package member mode differs: /{member['path']}")
+    version = runner.run(["modinfo", "-k", platform.release(), "-F", "version", MODULE_NAME]).stdout.strip()
+    require(version == manifest["productVersion"], "installed module metadata version differs from manifest")
+
+
+def apply_release(state_dir: pathlib.Path, resolved: Mapping[str, Any], record: pathlib.Path, root: pathlib.Path, runner: Runner) -> None:
+    manifest = resolved["manifest"]
+    package_path = pathlib.Path(str(resolved["packagePath"]))
+    require(package_path.parent == state_dir and package_path.is_file() and not package_path.is_symlink(), "prepared package was replaced before installation")
+    validate_package(package_path, manifest, runner)
+    inventory = existing_inventory(root, runner)
+    require(not inventory["activeModule"], "an active RP1 GPCLK module blocks ordinary installation")
+    require(not inventory["configuredRoute"], "a configured RP1 GPCLK route blocks ordinary installation")
+    require(not inventory["enrollment"] and not inventory["developmentManager"], "development enrollment or manager binding blocks release installation")
+    expected = manifest["debianVersion"]
+    if inventory["packageVersion"] is None:
+        require(
+            not inventory["dkms"] and not inventory["sourceTrees"]
+            and not inventory["moduleCandidates"] and not inventory["installedOverlays"],
+            "foreign or mixed RP1 GPCLK installation blocks package installation",
+        )
+        runner.run(["apt-get", "install", "--no-install-recommends", "-y", str(package_path)])
+    elif inventory["packageVersion"] == expected:
+        pass
+    else:
+        raise ContractError(f"existing RP1-GPCLK-DKMS {inventory['packageVersion']} requires its owning package migration workflow; automatic replacement refused")
+    verify_installed_release(root, manifest, runner)
+    record_value = {
+        "schema": RECORD_SCHEMA, "repository": REPOSITORY, "channel": "release",
+        "tag": resolved["tag"], "sourceCommit": resolved["commit"],
+        "productVersion": manifest["productVersion"], "debianVersion": manifest["debianVersion"],
+        "packageSha256": manifest["package"]["sha256"], "uapiSha256": manifest["uapi"]["sha256"],
+        "administrationProtocol": manifest["administrationProtocol"], "routeActivation": "disabled",
+        "output": "disabled", "qualificationClaim": False,
+    }
+    record.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    atomic_json(record, record_value)
+
+
+def verify_development_result(
+    manifest_path: pathlib.Path,
+    resolved: Mapping[str, Any],
+) -> dict[str, Any]:
+    require(manifest_path.is_file() and not manifest_path.is_symlink(), "upstream development result manifest is missing or substituted")
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ContractError("upstream development result manifest is unreadable") from error
+    require(isinstance(manifest, dict), "upstream development result manifest is not an object")
+    expected = {
+        "schema": "rp1-gpclk-source-development-manifest-v1",
+        "classification": "source-development",
+        "qualification": False,
+        "releaseQualified": False,
+        "sourceCommit": resolved["commit"],
+        "sourceState": "clean",
+        "renderedVersion": resolved["version"],
+        "dkmsName": DKMS_NAME,
+        "moduleName": MODULE_NAME,
+        "targetKernel": platform.release(),
+    }
+    for key, value in expected.items():
+        require(manifest.get(key) == value, f"upstream development result has incompatible {key}")
+    require(manifest.get("route") is None, "upstream development result selected a GPIO route")
+    uapi = manifest.get("uapiIdentity")
+    require(isinstance(uapi, dict) and uapi.get("sha256") == resolved["uapiSha256"], "upstream development result UAPI differs from the selected source")
+    parameters = manifest.get("parameters")
+    require(isinstance(parameters, dict) and parameters.get("live_output") == 0, "upstream development result did not retain output disabled")
+    installed = manifest.get("installedModule")
+    require(isinstance(installed, dict), "upstream development result lacks installed module identity")
+    require(installed.get("moduleName") == MODULE_NAME and installed.get("moduleVersion") == resolved["version"], "upstream installed module identity differs from the selected source")
+    require(installed.get("kernel") == platform.release(), "upstream installed module targets a different kernel")
+    for field in ("installedFileSha256", "decompressedElfSha256"):
+        require(isinstance(installed.get(field), str) and SHA256.fullmatch(installed[field]), f"upstream installed module lacks valid {field}")
+    return manifest
+
+
+def apply_development(resolved: Mapping[str, Any], record: pathlib.Path, runner: Runner) -> None:
+    source = revalidate_checkout(resolved["checkout"], runner)
+    interface, route_args = route_neutral_interface(source, runner)
+    require(interface == resolved["interface"] and route_args == resolved["routeArguments"], "upstream development interface changed after preflight")
+    before = existing_inventory(pathlib.Path("/"), runner)
+    require(not before["activeModule"], "an active RP1 GPCLK module blocks exact-source development installation")
+    require(not before["configuredRoute"], "a configured RP1 GPCLK route blocks exact-source development installation")
+    require(
+        before["packageVersion"] is None
+        and not before["dkms"]
+        and not before["sourceTrees"]
+        and not before["moduleCandidates"]
+        and not before["installedOverlays"]
+        and not before["enrollment"]
+        and not before["developmentManager"],
+        "an existing packaged, development, foreign, or mixed RP1 GPCLK installation requires its owning migration workflow",
+    )
+    evidence = record.parent / "rp1-gpclk-dkms-development-evidence"
+    evidence.mkdir(parents=True, exist_ok=False, mode=0o700)
+    command = [
+        str(source / "scripts" / "development-install"), "--source", str(source),
+        "--kernel", platform.release(), "--module-version", resolved["version"],
+        *route_args, "--live-output", "0", "--install", "--evidence-directory", str(evidence),
+    ]
+    runner.run(command, cwd=source)
+    result = verify_development_result(evidence / "rendered-source" / "DEVELOPMENT_MANIFEST.json", resolved)
+    after = existing_inventory(pathlib.Path("/"), runner)
+    require(not after["activeModule"], "RP1 GPCLK module became active during development installation")
+    require(not after["configuredRoute"], "RP1 GPCLK route became configured during development installation")
+    installed = result["installedModule"]
+    atomic_json(record, {
+        "schema": RECORD_SCHEMA, "repository": REPOSITORY, "channel": "development",
+        "sourceCommit": resolved["commit"], "productVersion": resolved["version"],
+        "sourceTree": resolved["sourceTree"], "uapiSha256": resolved["uapiSha256"],
+        "installedModuleSha256": installed["installedFileSha256"],
+        "decompressedModuleSha256": installed["decompressedElfSha256"],
+        "targetKernel": platform.release(),
+        "compatibilityIdentity": COMPATIBILITY_IDENTITY, "routeActivation": "disabled",
+        "output": "disabled", "qualificationClaim": False, "upstreamEvidence": str(evidence),
+    })
+
+
+def load_plan(state_dir: pathlib.Path) -> dict[str, Any]:
+    plan_path = state_dir / "plan.json"
+    require(plan_path.is_file() and not plan_path.is_symlink(), "prepared plan is missing or substituted")
+    try:
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ContractError("prepared plan is unreadable") from error
+    require(isinstance(plan, dict) and plan.get("schema") == STATE_SCHEMA, "prepared plan schema is invalid")
+    return plan
+
+
+def apply(args: argparse.Namespace, runner: Runner) -> None:
+    state_dir = secure_state_dir(args.state_dir)
+    plan = load_plan(state_dir)
+    require(not plan.get("dryRun"), "dry-run plan cannot be applied")
+    if not plan["decision"]["install"]:
+        print("RP1-GPCLK-DKMS installation skipped by resolved plan.")
+        return
+    resolved = plan.get("resolved")
+    require(isinstance(resolved, dict), "prepared installation identity is missing")
+    record = args.record
+    require(record.is_absolute(), "installation record path must be absolute")
+    secure_record_parent(record)
+    root = args.root.resolve(strict=True)
+    if resolved["channel"] == "release":
+        apply_release(state_dir, resolved, record, root, runner)
+    elif resolved["channel"] == "development":
+        apply_development(resolved, record, runner)
+    else:
+        raise ContractError("prepared source channel is invalid")
+    print("RP1-GPCLK-DKMS package/source and DKMS installation verified; route activation and output remain disabled.")
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    sub = result.add_subparsers(dest="command", required=True)
+    prepare_parser = sub.add_parser("prepare")
+    prepare_parser.add_argument("--state-dir", type=pathlib.Path, required=True)
+    prepare_parser.add_argument("--install", choices=("auto", "true", "false"), default="auto")
+    prepare_parser.add_argument("--source", default="auto")
+    prepare_parser.add_argument("--wsprry-source", required=True)
+    prepare_parser.add_argument("--model-file", type=pathlib.Path, default=pathlib.Path("/proc/device-tree/model"))
+    prepare_parser.add_argument("--compatible-file", type=pathlib.Path, default=pathlib.Path("/proc/device-tree/compatible"))
+    prepare_parser.add_argument("--dry-run", action="store_true")
+    apply_parser = sub.add_parser("apply")
+    apply_parser.add_argument("--state-dir", type=pathlib.Path, required=True)
+    apply_parser.add_argument("--record", type=pathlib.Path, default=pathlib.Path("/var/lib/wsprrypi/rp1-gpclk-dkms-installation.json"))
+    apply_parser.add_argument("--root", type=pathlib.Path, default=pathlib.Path("/"))
+    return result
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        if args.command == "prepare":
+            prepare(args, Runner())
+        else:
+            apply(args, Runner())
+    except ContractError as error:
+        print(f"RP1-GPCLK-DKMS installation refused: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rp1_gpclk_dkms_install.py
+++ b/scripts/rp1_gpclk_dkms_install.py
@@ -635,15 +635,29 @@ def clone_exact(state_dir: pathlib.Path, selector: str, value: str | None, runne
     return identity
 
 
-def development_version(source: pathlib.Path) -> str:
-    model = source / "release" / "installation-model-v1.json"
+def development_identity(source: pathlib.Path, runner: Runner) -> dict[str, str]:
+    preflight = source / "scripts" / "development-preflight"
+    require(preflight.is_file() and os.access(preflight, os.X_OK), "development source lacks the maintained preflight")
+    result = runner.run(
+        [str(preflight), "--source", str(source), "--kernel", platform.release()],
+        cwd=source,
+    )
     try:
-        payload = json.loads(model.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as error:
-        raise ContractError("development source lacks a readable upstream installation model") from error
-    version = payload.get("release")
-    require(isinstance(version, str) and SAFE_VERSION.fullmatch(version), "development source installation model has an invalid version")
-    return version
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise ContractError("upstream development preflight returned malformed identity") from error
+    require(isinstance(payload, dict), "upstream development preflight identity is not an object")
+    version = payload.get("moduleVersion")
+    version_source = payload.get("versionSource")
+    version_sha256 = payload.get("versionSourceSha256")
+    require(payload.get("classification") == "source-development", "upstream development preflight classification differs")
+    require(payload.get("moduleName") == MODULE_NAME, "upstream development preflight module identity differs")
+    require(isinstance(version, str) and SAFE_VERSION.fullmatch(version), "upstream development preflight has an invalid version")
+    require(version_source == "include/rp1_gpclk/version.h", "upstream development preflight version source differs")
+    path = source / version_source
+    require(path.is_file() and not path.is_symlink(), "upstream canonical development version source is missing or substituted")
+    require(version_sha256 == sha256_file(path), "upstream development version identity differs from the selected source")
+    return {"version": version, "versionSource": version_source, "versionSourceSha256": version_sha256}
 
 
 def route_neutral_interface(source: pathlib.Path, runner: Runner) -> tuple[str, list[str]]:
@@ -685,15 +699,16 @@ def prepare_development(state_dir: pathlib.Path, selector: str, value: str | Non
     else:
         identity = clone_exact(state_dir, selector, value, runner)
     source = pathlib.Path(identity["path"])
-    version = development_version(source)
     uapi = source / "include" / "uapi" / "linux" / "rp1_gpclk.h"
     require(uapi.is_file() and not uapi.is_symlink(), "development source lacks the canonical regular-file UAPI")
     interface, route_args = route_neutral_interface(source, runner)
-    runner.run([str(source / "scripts" / "development-preflight"), "--kernel", platform.release()], cwd=source)
+    upstream_identity = development_identity(source, runner)
     return {
-        "channel": "development", "commit": identity["commit"], "version": version,
+        "channel": "development", "commit": identity["commit"], "version": upstream_identity["version"],
         "checkout": identity, "interface": interface, "routeArguments": route_args,
         "sourceTree": identity["tree"], "uapiSha256": sha256_file(uapi),
+        "versionSource": upstream_identity["versionSource"],
+        "versionSourceSha256": upstream_identity["versionSourceSha256"],
         "compatibilityIdentity": COMPATIBILITY_IDENTITY,
     }
 
@@ -955,7 +970,22 @@ def verify_development_result(
     }
     for key, value in expected.items():
         require(manifest.get(key) == value, f"upstream development result has incompatible {key}")
+    require(manifest.get("installationMode") == "route-neutral", "upstream development result is not route-neutral")
+    version_identity = manifest.get("versionIdentity")
+    require(
+        isinstance(version_identity, dict)
+        and version_identity.get("path") == resolved["versionSource"]
+        and version_identity.get("sha256") == resolved["versionSourceSha256"]
+        and version_identity.get("moduleVersion") == resolved["version"],
+        "upstream development result canonical version identity differs from the selected source",
+    )
     require(manifest.get("route") is None, "upstream development result selected a GPIO route")
+    safety = manifest.get("routeNeutralSafety")
+    require(isinstance(safety, dict) and set(safety) == {"before", "after"}, "upstream development result lacks route-neutral safety observations")
+    for stage in ("before", "after"):
+        observation = safety.get(stage)
+        require(isinstance(observation, dict) and observation, f"upstream development result has invalid {stage} route-neutral observation")
+        require(not any(bool(value) for value in observation.values()), f"upstream development result reports a {stage} route-neutral blocker")
     uapi = manifest.get("uapiIdentity")
     require(isinstance(uapi, dict) and uapi.get("sha256") == resolved["uapiSha256"], "upstream development result UAPI differs from the selected source")
     parameters = manifest.get("parameters")
@@ -990,7 +1020,7 @@ def apply_development(resolved: Mapping[str, Any], record: pathlib.Path, runner:
     evidence.mkdir(parents=True, exist_ok=False, mode=0o700)
     command = [
         str(source / "scripts" / "development-install"), "--source", str(source),
-        "--kernel", platform.release(), "--module-version", resolved["version"],
+        "--kernel", platform.release(),
         *route_args, "--live-output", "0", "--install", "--evidence-directory", str(evidence),
     ]
     runner.run(command, cwd=source, passthrough=True)
@@ -1003,6 +1033,8 @@ def apply_development(resolved: Mapping[str, Any], record: pathlib.Path, runner:
         "schema": RECORD_SCHEMA, "repository": REPOSITORY, "channel": "development",
         "sourceCommit": resolved["commit"], "productVersion": resolved["version"],
         "sourceTree": resolved["sourceTree"], "uapiSha256": resolved["uapiSha256"],
+        "versionSource": resolved["versionSource"],
+        "versionSourceSha256": resolved["versionSourceSha256"],
         "installedModuleSha256": installed["installedFileSha256"],
         "decompressedModuleSha256": installed["decompressedElfSha256"],
         "targetKernel": platform.release(),

--- a/scripts/tests/rp1_gpclk_dkms_install_test.py
+++ b/scripts/tests/rp1_gpclk_dkms_install_test.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+"""Offline, unprivileged contract tests for RP1 provider installation."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import io
+import json
+import os
+import pathlib
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "rp1_gpclk_dkms_install.py"
+SPEC = importlib.util.spec_from_file_location("rp1_installer", SCRIPT)
+assert SPEC and SPEC.loader
+MOD = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MOD
+SPEC.loader.exec_module(MOD)
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def inventory_for_uapi(content: bytes = b"uapi\n") -> list[dict[str, object]]:
+    return [{
+        "path": "usr/src/rp1-gpclk-dkms-2.1.0/include/uapi/linux/rp1_gpclk.h",
+        "type": "file", "mode": "0644", "sha256": digest(content),
+    }]
+
+
+def valid_manifest(version: str = "2.1.0", commit: str = "a" * 40) -> dict[str, object]:
+    inventory = inventory_for_uapi()
+    return {
+        "schema": MOD.MANIFEST_SCHEMA,
+        "schemaVersion": 1,
+        "repository": MOD.REPOSITORY,
+        "releaseTag": f"v{version}",
+        "sourceCommit": commit,
+        "productVersion": version,
+        "debianVersion": f"{version}-1",
+        "package": {
+            "name": MOD.PACKAGE_NAME,
+            "filename": f"rp1-gpclk-dkms_{version}-1_all.deb",
+            "sha256": "b" * 64,
+        },
+        "dkmsModule": MOD.DKMS_NAME,
+        "kernelModule": MOD.MODULE_NAME,
+        "uapi": {
+            "abiMin": 4,
+            "abiMax": 4,
+            "sha256": inventory[0]["sha256"],
+            "path": inventory[0]["path"],
+        },
+        "administrationProtocol": MOD.ADMIN_PROTOCOL,
+        "installationBehavior": {
+            "routeNeutral": True,
+            "outputDisabled": True,
+            "loadsModule": False,
+            "appliesOverlay": False,
+            "editsBootConfiguration": False,
+            "operatesServices": False,
+        },
+        "packageInventory": inventory,
+        "packageInventorySha256": digest(MOD.canonical(inventory)),
+        "releaseChannel": "release",
+    }
+
+
+def release(tag: str, *, draft: bool = False, prerelease: bool = False, complete: bool = True) -> dict[str, object]:
+    names = []
+    if complete:
+        names = [MOD.MANIFEST_NAME, MOD.CHECKSUMS_NAME, f"rp1-gpclk-dkms_{tag.removeprefix('v')}-1_all.deb"]
+    return {
+        "tag_name": tag, "draft": draft, "prerelease": prerelease, "immutable": True,
+        "published_at": "2026-08-31T00:00:00Z",
+        "assets": [{"name": name, "state": "uploaded", "browser_download_url": f"https://github.com/{MOD.REPOSITORY}/releases/download/{tag}/{name}"} for name in names],
+    }
+
+
+class FakeRunner(MOD.Runner):
+    def __init__(self, responses: dict[tuple[str, ...], MOD.CommandResult] | None = None):
+        self.responses = responses or {}
+        self.calls: list[tuple[str, ...]] = []
+
+    def run(self, argv, *, check=True, cwd=None):
+        key = tuple(str(item) for item in argv)
+        self.calls.append(key)
+        result = self.responses.get(key, MOD.CommandResult("", "", 0))
+        if check and result.returncode:
+            raise MOD.ContractError(result.stderr or "fake command failure")
+        return result
+
+
+class PlatformAndSelectionTests(unittest.TestCase):
+    def detected(self, model: bytes, compatible: bytes):
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            (root / "model").write_bytes(model)
+            (root / "compatible").write_bytes(compatible)
+            return MOD.detect_platform(root / "model", root / "compatible")
+
+    def test_auto_pi5_and_cm5(self):
+        for model, compatible in (
+            (b"Raspberry Pi 5 Model B Rev 1.0\0", b"raspberrypi,5-model-b\0brcm,bcm2712\0"),
+            (b"Raspberry Pi Compute Module 5 Rev 1.0\0", b"raspberrypi,5-compute-module\0brcm,bcm2712d0\0"),
+        ):
+            detected = self.detected(model, compatible)
+            self.assertTrue(detected["automaticEligible"])
+            self.assertTrue(MOD.installation_decision("auto", detected)["install"])
+
+    def test_auto_skips_non_pi5_and_unknown(self):
+        for model, compatible in (
+            (b"Raspberry Pi 4 Model B\0", b"raspberrypi,4-model-b\0brcm,bcm2711\0"),
+            (b"", b""),
+            (b"Raspberry Pi 5 Model B Rev 1.0\0", b"raspberrypi,5-model-b\0"),
+        ):
+            decision = MOD.installation_decision("auto", self.detected(model, compatible))
+            self.assertFalse(decision["install"])
+            self.assertFalse(decision["platformOverride"])
+
+    def test_explicit_true_and_false(self):
+        unknown = {"automaticEligible": False}
+        enabled = MOD.installation_decision("true", unknown)
+        self.assertTrue(enabled["install"])
+        self.assertTrue(enabled["platformOverride"])
+        self.assertFalse(MOD.installation_decision("false", {"automaticEligible": True})["install"])
+        with self.assertRaises(MOD.ContractError):
+            MOD.installation_decision("yes", unknown)
+
+    def test_channel_and_source_selection(self):
+        for source in ("main", "master", "v3.2.0"):
+            self.assertEqual(MOD.wsprry_channel(source), "production")
+            self.assertEqual(MOD.source_selector("auto", MOD.wsprry_channel(source))[0], "release")
+        for source in ("devel", "codex/feature", "issue-412"):
+            self.assertEqual(MOD.wsprry_channel(source), "development")
+            self.assertEqual(MOD.source_selector("auto", MOD.wsprry_channel(source))[0], "devel")
+        for ambiguous in ("", "HEAD", "detached", "unknown"):
+            with self.assertRaises(MOD.ContractError):
+                MOD.wsprry_channel(ambiguous)
+        self.assertEqual(MOD.source_selector("release", "development"), ("release", None))
+        self.assertEqual(MOD.source_selector("commit:" + "c" * 40, "development"), ("commit", "c" * 40))
+        with self.assertRaises(MOD.ContractError):
+            MOD.source_selector("commit:abc123", "development")
+        with self.assertRaises(MOD.ContractError):
+            MOD.source_selector("checkout:relative", "development")
+        with self.assertRaises(MOD.ContractError):
+            MOD.source_selector("commit:" + "a" * 40 + ";modprobe", "development")
+
+
+class ReleaseTests(unittest.TestCase):
+    def test_semantic_ordering_and_exclusions(self):
+        selected = MOD.select_release([
+            release("v1.9.9"), release("v1.10.0"), release("v9.0.0", draft=True),
+            release("v8.0.0", prerelease=True), release("latest"), release("v7.0.0", complete=False),
+        ])
+        self.assertEqual(selected["tag_name"], "v1.10.0")
+
+    def test_historical_release_without_new_manifest_is_not_eligible(self):
+        with self.assertRaisesRegex(MOD.ContractError, "no eligible"):
+            MOD.select_release([release("v1.0.0", complete=False)])
+
+    def test_selected_highest_corruption_does_not_fallback(self):
+        selected = MOD.select_release([release("v2.0.0"), release("v1.9.0")])
+        self.assertEqual(selected["tag_name"], "v2.0.0")
+        broken = valid_manifest("2.0.0", "d" * 40)
+        broken["repository"] = "attacker/repository"
+        with self.assertRaisesRegex(MOD.ContractError, "repository substitution"):
+            MOD.validate_manifest(broken, tag="v2.0.0", tag_commit="d" * 40)
+
+    def test_manifest_contract(self):
+        manifest = valid_manifest()
+        validated = MOD.validate_manifest(manifest, tag="v2.1.0", tag_commit="a" * 40)
+        self.assertEqual(validated["uapi"]["abiMin"], 4)
+        mutations = [
+            ("schema", "bad"), ("repository", "other/repo"), ("sourceCommit", "c" * 40),
+            ("releaseChannel", "development"), ("administrationProtocol", "shell-v0"),
+            ("dkmsModule", "other"),
+        ]
+        for field, value in mutations:
+            candidate = copy.deepcopy(manifest)
+            candidate[field] = value
+            with self.assertRaises(MOD.ContractError, msg=field):
+                MOD.validate_manifest(candidate, tag="v2.1.0", tag_commit="a" * 40)
+
+        candidate = copy.deepcopy(manifest)
+        candidate["installationBehavior"]["loadsModule"] = True
+        with self.assertRaisesRegex(MOD.ContractError, "inactive installation behavior"):
+            MOD.validate_manifest(candidate, tag="v2.1.0", tag_commit="a" * 40)
+
+    def test_missing_manifest_uapi_and_inventory_hash_refused(self):
+        for mutation in ("missing", "unexpected", "uapi", "inventory"):
+            candidate = copy.deepcopy(valid_manifest())
+            if mutation == "missing":
+                del candidate["package"]
+            elif mutation == "unexpected":
+                candidate["alternateRepository"] = "attacker/repository"
+            elif mutation == "uapi":
+                candidate["uapi"]["sha256"] = "e" * 64
+            else:
+                candidate["packageInventorySha256"] = "f" * 64
+            with self.assertRaises(MOD.ContractError, msg=mutation):
+                MOD.validate_manifest(candidate, tag="v2.1.0", tag_commit="a" * 40)
+
+    def test_checksum_parser_and_authoritative_urls(self):
+        parsed = MOD.parse_checksums(("a" * 64 + "  file.deb\n").encode())
+        self.assertEqual(parsed["file.deb"], "a" * 64)
+        for unsafe in (
+            "A" * 64 + "  file.deb\n",
+            "a" * 64 + " *file.deb\n",
+            "a" * 64 + "  ../file.deb\n",
+            "a" * 64 + "  file.deb\n" + "b" * 64 + "  file.deb\n",
+        ):
+            with self.assertRaises(MOD.ContractError):
+                MOD.parse_checksums(unsafe.encode())
+        good = f"https://github.com/{MOD.REPOSITORY}/releases/download/v2.1.0/file.deb"
+        MOD.authoritative_asset_url("v2.1.0", "file.deb", good)
+        for bad in (good.replace("github.com", "evil.example"), good + "?token=1", good.replace("v2.1.0", "v2.0.0")):
+            with self.assertRaises(MOD.ContractError):
+                MOD.authoritative_asset_url("v2.1.0", "file.deb", bad)
+
+    def test_asset_download_does_not_forward_api_token(self):
+        class Response:
+            headers = {"Content-Length": "2"}
+            def __enter__(self): return self
+            def __exit__(self, *_): return False
+            def geturl(self): return "https://release-assets.githubusercontent.com/asset"
+            def read(self, _): return b"ok"
+
+        observed = {}
+        def fake_open(request, timeout):
+            observed["authorization"] = request.get_header("Authorization")
+            observed["timeout"] = timeout
+            return Response()
+
+        with mock.patch.object(MOD.urllib.request, "urlopen", side_effect=fake_open):
+            value = MOD.GitHubClient("secret-token").bytes(
+                "https://github.com/WsprryPi/RP1-GPCLK-DKMS/releases/download/v2.1.0/file.deb",
+                allow_asset_redirect=True,
+            )
+        self.assertEqual(value, b"ok")
+        self.assertIsNone(observed["authorization"])
+
+
+class ArchiveTests(unittest.TestCase):
+    def make_tar(self, members):
+        temporary = tempfile.NamedTemporaryFile(suffix=".tar", delete=False)
+        temporary.close()
+        path = pathlib.Path(temporary.name)
+        with tarfile.open(path, "w") as archive:
+            for name, kind, content in members:
+                info = tarfile.TarInfo(name)
+                info.mode = 0o644
+                if kind == "file":
+                    info.size = len(content)
+                    archive.addfile(info, io.BytesIO(content))
+                elif kind == "symlink":
+                    info.type = tarfile.SYMTYPE
+                    info.linkname = content.decode()
+                    archive.addfile(info)
+                elif kind == "hardlink":
+                    info.type = tarfile.LNKTYPE
+                    info.linkname = content.decode()
+                    archive.addfile(info)
+        self.addCleanup(path.unlink, missing_ok=True)
+        return path
+
+    def test_safe_inventory(self):
+        path = self.make_tar([("./usr/include/uapi.h", "file", b"header")])
+        inventory = MOD.tar_inventory(path)
+        self.assertEqual(inventory[0]["path"], "usr/include/uapi.h")
+        self.assertEqual(inventory[0]["sha256"], digest(b"header"))
+
+    def test_member_size_and_inventory_count_are_bounded(self):
+        path = self.make_tar([("usr/large", "file", b"xx")])
+        with mock.patch.object(MOD, "MAX_PACKAGE_MEMBER_BYTES", 1):
+            with self.assertRaisesRegex(MOD.ContractError, "bounded size"):
+                MOD.tar_inventory(path)
+        with mock.patch.object(MOD, "MAX_PACKAGE_MEMBERS", 0):
+            with self.assertRaisesRegex(MOD.ContractError, "bounded member"):
+                MOD.validate_inventory(inventory_for_uapi())
+
+    def test_path_traversal_symlink_escape_and_special_refused(self):
+        for members in (
+            [("../escape", "file", b"x")],
+            [("usr/link", "symlink", b"../../escape")],
+            [("usr/hard", "hardlink", b"usr/target")],
+        ):
+            with self.assertRaises(MOD.ContractError):
+                MOD.tar_inventory(self.make_tar(members))
+
+
+class CheckoutTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.repo = pathlib.Path(self.temp.name).resolve() / "repo"
+        self.repo.mkdir()
+        subprocess.run(["git", "init", "-q", str(self.repo)], check=True)
+        subprocess.run(["git", "-C", str(self.repo), "config", "user.email", "test@example.invalid"], check=True)
+        subprocess.run(["git", "-C", str(self.repo), "config", "user.name", "Test"], check=True)
+        (self.repo / "tracked").write_text("clean\n")
+        subprocess.run(["git", "-C", str(self.repo), "add", "tracked"], check=True)
+        subprocess.run(["git", "-C", str(self.repo), "commit", "-q", "-m", "fixture"], check=True)
+        subprocess.run(["git", "-C", str(self.repo), "remote", "add", "origin", MOD.REPOSITORY_URL], check=True)
+
+    def test_clean_checkout_acceptance(self):
+        identity = MOD.validate_checkout(str(self.repo), MOD.Runner())
+        self.assertRegex(identity["commit"], r"^[0-9a-f]{40}$")
+        self.assertEqual(MOD.revalidate_checkout(identity, MOD.Runner()), self.repo)
+
+    def test_dirty_untracked_relative_symlink_and_unrelated_refused(self):
+        (self.repo / "untracked").write_text("x")
+        with self.assertRaisesRegex(MOD.ContractError, "tracked or untracked"):
+            MOD.validate_checkout(str(self.repo), MOD.Runner())
+        (self.repo / "untracked").unlink()
+        with self.assertRaises(MOD.ContractError):
+            MOD.validate_checkout("relative", MOD.Runner())
+        link = pathlib.Path(self.temp.name) / "link"
+        link.symlink_to(self.repo, target_is_directory=True)
+        with self.assertRaisesRegex(MOD.ContractError, "symlink"):
+            MOD.validate_checkout(str(link), MOD.Runner())
+        subprocess.run(["git", "-C", str(self.repo), "remote", "set-url", "origin", "https://example.invalid/other.git"], check=True)
+        with self.assertRaisesRegex(MOD.ContractError, "authoritative"):
+            MOD.validate_checkout(str(self.repo), MOD.Runner())
+
+    def test_checkout_toctou_change_refused(self):
+        identity = MOD.validate_checkout(str(self.repo), MOD.Runner())
+        (self.repo / "tracked").write_text("replaced\n")
+        with self.assertRaisesRegex(MOD.ContractError, "dirty or replaced"):
+            MOD.revalidate_checkout(identity, MOD.Runner())
+
+    def test_devel_and_exact_commit_resolve_once_to_detached_sha(self):
+        bare = pathlib.Path(self.temp.name).resolve() / "authoritative.git"
+        subprocess.run(["git", "clone", "-q", "--bare", str(self.repo), str(bare)], check=True)
+        subprocess.run(["git", "-C", str(self.repo), "push", "-q", str(bare), "HEAD:refs/heads/devel"], check=True)
+        commit = subprocess.run(
+            ["git", "-C", str(self.repo), "rev-parse", "HEAD"],
+            check=True, text=True, stdout=subprocess.PIPE,
+        ).stdout.strip()
+        with mock.patch.object(MOD, "REPOSITORY_URL", str(bare)):
+            devel_state = pathlib.Path(self.temp.name).resolve() / "devel-state"
+            devel_state.mkdir()
+            devel = MOD.clone_exact(devel_state, "devel", None, MOD.Runner())
+            self.assertEqual(devel["commit"], commit)
+            head_name = subprocess.run(
+                ["git", "-C", devel["path"], "symbolic-ref", "-q", "HEAD"],
+                text=True, stdout=subprocess.PIPE,
+            )
+            self.assertNotEqual(head_name.returncode, 0)
+            commit_state = pathlib.Path(self.temp.name).resolve() / "commit-state"
+            commit_state.mkdir()
+            exact = MOD.clone_exact(commit_state, "commit", commit, MOD.Runner())
+            self.assertEqual(exact["commit"], commit)
+            missing_state = pathlib.Path(self.temp.name).resolve() / "missing-state"
+            missing_state.mkdir()
+            with self.assertRaisesRegex(MOD.ContractError, "does not exist"):
+                MOD.clone_exact(missing_state, "commit", "f" * 40, MOD.Runner())
+
+
+class DevelopmentInterfaceTests(unittest.TestCase):
+    def lifecycle_source(self, help_text: str) -> pathlib.Path:
+        root = pathlib.Path(self.temp.name)
+        scripts = root / "scripts"
+        scripts.mkdir(exist_ok=True)
+        installer = scripts / "development-install"
+        installer.write_text(f"#!/bin/sh\nprintf '%s\\n' '{help_text}'\n")
+        preflight = scripts / "development-preflight"
+        preflight.write_text("#!/bin/sh\nexit 0\n")
+        installer.chmod(0o755)
+        preflight.chmod(0o755)
+        return root
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+
+    def test_current_route_required_upstream_is_explicit_blocker(self):
+        source = self.lifecycle_source("usage: development-install --route {gpio4,gpio20}")
+        with self.assertRaisesRegex(MOD.ContractError, "no reviewed route-neutral"):
+            MOD.route_neutral_interface(source, MOD.Runner())
+
+    def test_future_reviewed_route_neutral_shapes(self):
+        source = self.lifecycle_source("usage: development-install --route-neutral")
+        self.assertEqual(MOD.route_neutral_interface(source, MOD.Runner())[1], ["--route-neutral"])
+        source = self.lifecycle_source("usage: development-install --route {gpio4,gpio20,route-neutral}")
+        self.assertEqual(MOD.route_neutral_interface(source, MOD.Runner())[1], ["--route", "route-neutral"])
+
+    def test_development_result_is_bound_before_recording(self):
+        manifest_path = pathlib.Path(self.temp.name) / "DEVELOPMENT_MANIFEST.json"
+        resolved = {"commit": "a" * 40, "version": "0.9.0", "uapiSha256": "b" * 64}
+        manifest = {
+            "schema": "rp1-gpclk-source-development-manifest-v1",
+            "classification": "source-development", "qualification": False,
+            "releaseQualified": False, "sourceCommit": "a" * 40,
+            "sourceState": "clean", "renderedVersion": "0.9.0",
+            "dkmsName": MOD.DKMS_NAME, "moduleName": MOD.MODULE_NAME,
+            "targetKernel": MOD.platform.release(),
+            "uapiIdentity": {"sha256": "b" * 64},
+            "parameters": {"live_output": 0},
+            "installedModule": {
+                "moduleName": MOD.MODULE_NAME, "moduleVersion": "0.9.0",
+                "kernel": MOD.platform.release(), "installedFileSha256": "c" * 64,
+                "decompressedElfSha256": "d" * 64,
+            },
+        }
+        manifest_path.write_text(json.dumps(manifest))
+        self.assertEqual(MOD.verify_development_result(manifest_path, resolved)["sourceState"], "clean")
+        for field, value in (("route", "gpio4"), ("sourceState", "dirty-explicitly-allowed")):
+            candidate = copy.deepcopy(manifest)
+            candidate[field] = value
+            manifest_path.write_text(json.dumps(candidate))
+            with self.assertRaises(MOD.ContractError):
+                MOD.verify_development_result(manifest_path, resolved)
+
+    def test_existing_foreign_state_blocks_development_before_mutation(self):
+        source = self.lifecycle_source("usage: development-install --route-neutral")
+        resolved = {
+            "checkout": {"path": str(source)}, "interface": "route-neutral-flag",
+            "routeArguments": ["--route-neutral"], "version": "0.9.0",
+        }
+        existing = {
+            "packageVersion": None, "dkms": "rp1-gpclk-dkms/foreign, kernel: installed",
+            "activeModule": False, "configuredRoute": False, "sourceTrees": [],
+            "moduleCandidates": [], "installedOverlays": [], "enrollment": False,
+            "developmentManager": False,
+        }
+        record = pathlib.Path(self.temp.name) / "record.json"
+        with mock.patch.object(MOD, "revalidate_checkout", return_value=source), \
+             mock.patch.object(MOD, "existing_inventory", return_value=existing):
+            with self.assertRaisesRegex(MOD.ContractError, "foreign.*mixed"):
+                MOD.apply_development(resolved, record, MOD.Runner())
+        self.assertFalse(record.exists())
+
+
+class ApplyPolicyTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = pathlib.Path(self.temp.name).resolve()
+        (self.root / "proc").mkdir()
+        (self.root / "proc/modules").write_text("")
+        self.state = self.root / "state"
+        self.state.mkdir(mode=0o700)
+        self.package = self.state / "rp1-gpclk-dkms_2.1.0-1_all.deb"
+        self.package.write_bytes(b"fixture")
+        self.manifest = valid_manifest()
+        self.resolved = {"tag": "v2.1.0", "commit": "a" * 40, "manifest": self.manifest, "packagePath": str(self.package)}
+        self.record = self.root / "record.json"
+
+    def responses(self, installed_version=None, dkms=""):
+        dpkg = MOD.CommandResult("", "missing", 1)
+        if installed_version:
+            dpkg = MOD.CommandResult(f"install ok installed\n{installed_version}\n", "", 0)
+        return {
+            ("dpkg-query", "-W", "-f=${Status}\n${Version}\n", MOD.PACKAGE_NAME): dpkg,
+            ("dkms", "status", "-m", MOD.DKMS_NAME): MOD.CommandResult(dkms, "", 0),
+        }
+
+    def test_foreign_and_mixed_state_refused_before_apt(self):
+        source = self.root / "usr/src/rp1-gpclk-dkms-foreign"
+        source.mkdir(parents=True)
+        runner = FakeRunner(self.responses())
+        with mock.patch.object(MOD, "validate_package"):
+            with self.assertRaisesRegex(MOD.ContractError, "foreign or mixed"):
+                MOD.apply_release(self.state, self.resolved, self.record, self.root, runner)
+        self.assertFalse(any(call and call[0] == "apt-get" for call in runner.calls))
+
+    def test_different_installed_version_requires_owner_migration(self):
+        runner = FakeRunner(self.responses("1.0.1-1"))
+        with mock.patch.object(MOD, "validate_package"):
+            with self.assertRaisesRegex(MOD.ContractError, "owning package migration"):
+                MOD.apply_release(self.state, self.resolved, self.record, self.root, runner)
+        self.assertFalse(any(call and call[0] == "apt-get" for call in runner.calls))
+
+    def test_active_module_and_development_manager_refused(self):
+        (self.root / "proc/modules").write_text(f"{MOD.MODULE_NAME} 1 0 - Live 0x0\n")
+        runner = FakeRunner(self.responses())
+        with mock.patch.object(MOD, "validate_package"):
+            with self.assertRaisesRegex(MOD.ContractError, "active"):
+                MOD.apply_release(self.state, self.resolved, self.record, self.root, runner)
+        self.assertFalse(any(call and call[0] == "apt-get" for call in runner.calls))
+
+    def test_exact_installation_is_idempotent(self):
+        member = self.manifest["packageInventory"][0]
+        installed = self.root / member["path"]
+        installed.parent.mkdir(parents=True)
+        installed.write_bytes(b"uapi\n")
+        responses = self.responses(
+            "2.1.0-1",
+            "rp1-gpclk-dkms/2.1.0, fixture-kernel, arm64: installed\n",
+        )
+        responses[("modinfo", "-k", MOD.platform.release(), "-F", "version", MOD.MODULE_NAME)] = MOD.CommandResult("2.1.0\n", "", 0)
+        runner = FakeRunner(responses)
+        with mock.patch.object(MOD, "validate_package"):
+            MOD.apply_release(self.state, self.resolved, self.record, self.root, runner)
+        self.assertFalse(any(call and call[0] == "apt-get" for call in runner.calls))
+        recorded = json.loads(self.record.read_text())
+        self.assertEqual(recorded["sourceCommit"], "a" * 40)
+        self.assertFalse(recorded["qualificationClaim"])
+
+    def test_exact_installation_rejects_foreign_same_version_state(self):
+        member = self.manifest["packageInventory"][0]
+        installed = self.root / member["path"]
+        installed.parent.mkdir(parents=True)
+        installed.write_bytes(b"uapi\n")
+        (self.root / "usr/src/rp1-gpclk-dkms-foreign").mkdir()
+        runner = FakeRunner(self.responses(
+            "2.1.0-1",
+            "rp1-gpclk-dkms/2.1.0, fixture-kernel, arm64: installed\n",
+        ))
+        with mock.patch.object(MOD, "validate_package"):
+            with self.assertRaisesRegex(MOD.ContractError, "source destinations"):
+                MOD.apply_release(self.state, self.resolved, self.record, self.root, runner)
+
+    def test_fresh_release_uses_normal_debian_path(self):
+        runner = FakeRunner(self.responses())
+        with mock.patch.object(MOD, "validate_package"), mock.patch.object(MOD, "verify_installed_release"):
+            MOD.apply_release(self.state, self.resolved, self.record, self.root, runner)
+        apt_calls = [call for call in runner.calls if call and call[0] == "apt-get"]
+        self.assertEqual(apt_calls, [("apt-get", "install", "--no-install-recommends", "-y", str(self.package))])
+
+    def test_dry_run_plan_cannot_be_applied(self):
+        model = self.root / "model"
+        compatible = self.root / "compatible"
+        model.write_bytes(b"Unknown\0")
+        compatible.write_bytes(b"")
+        args = MOD.parser().parse_args([
+            "prepare", "--state-dir", str(self.state), "--install", "false",
+            "--source", "auto", "--wsprry-source", "main",
+            "--model-file", str(model), "--compatible-file", str(compatible), "--dry-run",
+        ])
+        plan = MOD.prepare(args, FakeRunner())
+        self.assertTrue(plan["dryRun"])
+        apply_args = MOD.parser().parse_args([
+            "apply", "--state-dir", str(self.state), "--record", str(self.record), "--root", str(self.root),
+        ])
+        with self.assertRaisesRegex(MOD.ContractError, "dry-run"):
+            MOD.apply(apply_args, FakeRunner())
+
+    def test_uninstall_and_forbidden_operations_absent_from_installer_paths(self):
+        install_source = (ROOT / "scripts/install.sh").read_text()
+        helper_source = SCRIPT.read_text()
+        self.assertIn('[[ "$ACTION" == "install" ]] || return 0', install_source)
+        self.assertNotRegex(helper_source, r'\["(?:dtoverlay|modprobe|insmod|rmmod|systemctl|service|reboot|shutdown)"')
+        self.assertNotIn("apt-get remove", helper_source)
+        self.assertNotRegex(helper_source, r"config\.txt[^\n]*(?:write|replace|unlink)")
+
+    def test_prepare_precedes_package_mutation_and_apply_follows_dependencies(self):
+        source = (ROOT / "scripts/install.sh").read_text()
+        prepare = source.index('prepare_rp1_gpclk_dkms_installation "$debug" || return 1')
+        packages = source.index('handle_apt_packages "$debug" || return 1')
+        apply = source.index('apply_rp1_gpclk_dkms_installation "$debug" || return 1')
+        self.assertLess(prepare, packages)
+        self.assertLess(packages, apply)
+
+    def test_explicit_true_reaches_planner_without_raspberry_pi_identity(self):
+        source = (ROOT / "scripts/install.sh").read_text()
+
+        def function_body(name):
+            start = source.index(f"{name}() {{")
+            return source[start:source.index("\n}\n", start) + 3]
+
+        for name in ("validate_sys_accs", "print_model_name", "check_arch"):
+            body = function_body(name)
+            self.assertIn('INSTALL_RP1_GPCLK_DKMS" == "true"', body)
+            self.assertIn("explicitly requested", body)
+        self.assertIn('"$file" == "/proc/device-tree/compatible"', function_body("validate_sys_accs"))
+
+    def test_temporary_cleanup_is_scoped_and_uninstall_preserves_provider(self):
+        source = (ROOT / "scripts/install.sh").read_text()
+        cleanup_start = source.index("cleanup_rp1_gpclk_dkms_state() {")
+        cleanup = source[cleanup_start:source.index("\n}\n", cleanup_start) + 3]
+        self.assertIn("/tmp/wsprrypi-rp1-gpclk-dkms.*", cleanup)
+        self.assertIn("Refusing to remove unexpected", cleanup)
+        self.assertIn('[[ "$ACTION" == "install" ]] || return 0', source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/rp1_gpclk_dkms_install_test.py
+++ b/scripts/tests/rp1_gpclk_dkms_install_test.py
@@ -188,9 +188,9 @@ class ReleaseTests(unittest.TestCase):
         ])
         self.assertEqual(selected["tag_name"], "v1.10.0")
 
-    def test_historical_release_without_new_manifest_is_not_eligible(self):
+    def test_release_without_required_manifest_is_not_eligible(self):
         with self.assertRaisesRegex(MOD.ContractError, "no eligible"):
-            MOD.select_release([release("v1.0.0", complete=False)])
+            MOD.select_release([release("v2.0.0", complete=False)])
 
     def test_selected_highest_corruption_does_not_fallback(self):
         selected = MOD.select_release([release("v2.0.0"), release("v1.9.0")])
@@ -395,10 +395,18 @@ class DevelopmentInterfaceTests(unittest.TestCase):
         root = pathlib.Path(self.temp.name)
         scripts = root / "scripts"
         scripts.mkdir(exist_ok=True)
+        version_source = root / "include/rp1_gpclk/version.h"
+        version_source.parent.mkdir(parents=True, exist_ok=True)
+        version_source.write_text('#define RP1_GPCLK_MODULE_VERSION "0.9.0"\n')
         installer = scripts / "development-install"
         installer.write_text(f"#!/bin/sh\nprintf '%s\\n' '{help_text}'\n")
         preflight = scripts / "development-preflight"
-        preflight.write_text("#!/bin/sh\nexit 0\n")
+        identity = {
+            "classification": "source-development", "moduleName": MOD.MODULE_NAME,
+            "moduleVersion": "0.9.0", "versionSource": "include/rp1_gpclk/version.h",
+            "versionSourceSha256": digest(version_source.read_bytes()),
+        }
+        preflight.write_text("#!/bin/sh\nprintf '%s\\n' '" + json.dumps(identity) + "'\n")
         installer.chmod(0o755)
         preflight.chmod(0o755)
         return root
@@ -418,16 +426,33 @@ class DevelopmentInterfaceTests(unittest.TestCase):
         source = self.lifecycle_source("usage: development-install --route {gpio4,gpio20,route-neutral}")
         self.assertEqual(MOD.route_neutral_interface(source, MOD.Runner())[1], ["--route", "route-neutral"])
 
+    def test_development_identity_comes_from_upstream_preflight(self):
+        source = self.lifecycle_source("usage: development-install --route-neutral")
+        identity = MOD.development_identity(source, MOD.Runner())
+        self.assertEqual(identity["version"], "0.9.0")
+        self.assertEqual(identity["versionSource"], "include/rp1_gpclk/version.h")
+        (source / "include/rp1_gpclk/version.h").write_text('#define RP1_GPCLK_MODULE_VERSION "changed"\n')
+        with self.assertRaisesRegex(MOD.ContractError, "differs from the selected source"):
+            MOD.development_identity(source, MOD.Runner())
+
     def test_development_result_is_bound_before_recording(self):
         manifest_path = pathlib.Path(self.temp.name) / "DEVELOPMENT_MANIFEST.json"
-        resolved = {"commit": "a" * 40, "version": "0.9.0", "uapiSha256": "b" * 64}
+        resolved = {"commit": "a" * 40, "version": "0.9.0", "uapiSha256": "b" * 64,
+                    "versionSource": "include/rp1_gpclk/version.h", "versionSourceSha256": "e" * 64}
         manifest = {
             "schema": "rp1-gpclk-source-development-manifest-v1",
             "classification": "source-development", "qualification": False,
             "releaseQualified": False, "sourceCommit": "a" * 40,
             "sourceState": "clean", "renderedVersion": "0.9.0",
+            "versionIdentity": {"path": "include/rp1_gpclk/version.h", "sha256": "e" * 64,
+                                "moduleVersion": "0.9.0"},
             "dkmsName": MOD.DKMS_NAME, "moduleName": MOD.MODULE_NAME,
             "targetKernel": MOD.platform.release(),
+            "installationMode": "route-neutral", "route": None,
+            "routeNeutralSafety": {
+                "before": {"loadedModule": False, "configuredRoutes": []},
+                "after": {"loadedModule": False, "configuredRoutes": []},
+            },
             "uapiIdentity": {"sha256": "b" * 64},
             "parameters": {"live_output": 0},
             "installedModule": {
@@ -499,7 +524,7 @@ class ApplyPolicyTests(unittest.TestCase):
         self.assertFalse(any(call and call[0] == "apt-get" for call in runner.calls))
 
     def test_different_installed_version_requires_owner_migration(self):
-        runner = FakeRunner(self.responses("1.0.1-1"))
+        runner = FakeRunner(self.responses("9.9.9-1"))
         with mock.patch.object(MOD, "validate_package"):
             with self.assertRaisesRegex(MOD.ContractError, "owning package migration"):
                 MOD.apply_release(self.state, self.resolved, self.record, self.root, runner)

--- a/scripts/tests/rp1_gpclk_dkms_install_test.py
+++ b/scripts/tests/rp1_gpclk_dkms_install_test.py
@@ -90,12 +90,16 @@ def release(tag: str, *, draft: bool = False, prerelease: bool = False, complete
 
 class FakeRunner(MOD.Runner):
     def __init__(self, responses: dict[tuple[str, ...], MOD.CommandResult] | None = None):
+        super().__init__()
         self.responses = responses or {}
         self.calls: list[tuple[str, ...]] = []
+        self.passthrough_calls: list[tuple[str, ...]] = []
 
-    def run(self, argv, *, check=True, cwd=None):
+    def run(self, argv, *, check=True, cwd=None, passthrough=False):
         key = tuple(str(item) for item in argv)
         self.calls.append(key)
+        if passthrough:
+            self.passthrough_calls.append(key)
         result = self.responses.get(key, MOD.CommandResult("", "", 0))
         if check and result.returncode:
             raise MOD.ContractError(result.stderr or "fake command failure")
@@ -156,6 +160,24 @@ class PlatformAndSelectionTests(unittest.TestCase):
             MOD.source_selector("checkout:relative", "development")
         with self.assertRaises(MOD.ContractError):
             MOD.source_selector("commit:" + "a" * 40 + ";modprobe", "development")
+
+    def test_debug_runner_reports_argv_and_captured_output(self):
+        completed = subprocess.CompletedProcess(["git", "status"], 0, "clean\n", "notice\n")
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with mock.patch.object(MOD.subprocess, "run", return_value=completed), \
+             mock.patch.object(MOD.sys, "stdout", stdout), \
+             mock.patch.object(MOD.sys, "stderr", stderr):
+            result = MOD.Runner(debug=True).run(["git", "status"])
+        self.assertEqual(result.stdout, "clean\n")
+        self.assertEqual(stdout.getvalue(), "clean\n")
+        self.assertIn("[RP1 DEBUG] command: git status", stderr.getvalue())
+        self.assertIn("notice", stderr.getvalue())
+
+    def test_passthrough_failure_remains_a_contract_error(self):
+        completed = subprocess.CompletedProcess(["apt-get", "install"], 1, None, None)
+        with mock.patch.object(MOD.subprocess, "run", return_value=completed):
+            with self.assertRaisesRegex(MOD.ContractError, "see command output above"):
+                MOD.Runner().run(["apt-get", "install"], passthrough=True)
 
 
 class ReleaseTests(unittest.TestCase):
@@ -529,6 +551,7 @@ class ApplyPolicyTests(unittest.TestCase):
             MOD.apply_release(self.state, self.resolved, self.record, self.root, runner)
         apt_calls = [call for call in runner.calls if call and call[0] == "apt-get"]
         self.assertEqual(apt_calls, [("apt-get", "install", "--no-install-recommends", "-y", str(self.package))])
+        self.assertEqual(runner.passthrough_calls, apt_calls)
 
     def test_dry_run_plan_cannot_be_applied(self):
         model = self.root / "model"
@@ -548,6 +571,98 @@ class ApplyPolicyTests(unittest.TestCase):
         with self.assertRaisesRegex(MOD.ContractError, "dry-run"):
             MOD.apply(apply_args, FakeRunner())
 
+    def test_selected_shell_dry_run_never_invokes_python_or_resolution_tools(self):
+        install_script = ROOT / "scripts" / "install.sh"
+        shell = r'''
+source "$INSTALL_SCRIPT"
+python3() { printf python3 >"$SENTINEL"; return 99; }
+curl() { printf curl >"$SENTINEL"; return 99; }
+mktemp() { printf mktemp >"$SENTINEL"; return 99; }
+git() { printf git >"$SENTINEL"; return 99; }
+apt-get() { printf apt-get >"$SENTINEL"; return 99; }
+dpkg-deb() { printf dpkg-deb >"$SENTINEL"; return 99; }
+DRY_RUN=true
+ACTION=install
+INSTALL_RP1_GPCLK_DKMS=true
+RP1_GPCLK_DKMS_SOURCE="$SOURCE_SELECTOR"
+REPO_BRANCH="$WSPRRYPi_BRANCH"
+FGGLD= RESET= FGGRN= FGRED= MOVE_UP= CLEAR_LINE=
+prepare_rp1_gpclk_dkms_installation
+apply_rp1_gpclk_dkms_installation
+[[ ! -e "$SENTINEL" ]]
+cleanup_rp1_gpclk_dkms_state
+[[ -z "$RP1_GPCLK_DKMS_STATE_DIR" && -z "$RP1_GPCLK_DKMS_HELPER" ]]
+'''
+        for selector, branch in (("release", "main"), ("devel", "codex/issue-412-test")):
+            sentinel = self.root / f"{selector}.invoked"
+            environment = os.environ.copy()
+            environment.update({
+                "INSTALL_SCRIPT": str(install_script),
+                "SENTINEL": str(sentinel),
+                "SOURCE_SELECTOR": selector,
+                "WSPRRYPi_BRANCH": branch,
+            })
+            result = subprocess.run(
+                ["bash", "-c", shell], text=True, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, env=environment, check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(sentinel.exists())
+            self.assertEqual(result.stdout.count("(dry)"), 4)
+
+    def test_exec_command_preserves_internal_debug_argv(self):
+        install_script = ROOT / "scripts" / "install.sh"
+        capture = self.root / "argv.txt"
+        shell = r'''
+source "$INSTALL_SCRIPT"
+probe() { printf '%s\n' "$@" >"$CAPTURE"; }
+logD() { :; }
+DRY_RUN=false
+FGGLD= RESET= FGGRN= FGRED= MOVE_UP= CLEAR_LINE=
+exec_command "argv fidelity" probe before debug after debug
+'''
+        environment = os.environ.copy()
+        environment.update({"INSTALL_SCRIPT": str(install_script), "CAPTURE": str(capture)})
+        result = subprocess.run(
+            ["bash", "-c", shell], text=True, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, env=environment, check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(capture.read_text().splitlines(), ["before", "debug", "after"])
+
+    def test_shell_propagates_debug_to_both_helper_invocations(self):
+        install_script = ROOT / "scripts" / "install.sh"
+        capture = self.root / "helper-argv.txt"
+        shell = r'''
+source "$INSTALL_SCRIPT"
+python3() {
+    {
+        printf 'CALL\n'
+        printf 'ARG=%s\n' "$@"
+    } >>"$CAPTURE"
+}
+logD() { :; }
+DRY_RUN=false
+ACTION=install
+INSTALL_RP1_GPCLK_DKMS=true
+RP1_GPCLK_DKMS_SOURCE=release
+REPO_BRANCH=main
+FGGLD= RESET= FGGRN= FGRED= MOVE_UP= CLEAR_LINE=
+prepare_rp1_gpclk_dkms_installation debug
+apply_rp1_gpclk_dkms_installation debug
+cleanup_rp1_gpclk_dkms_state
+'''
+        environment = os.environ.copy()
+        environment.update({"INSTALL_SCRIPT": str(install_script), "CAPTURE": str(capture)})
+        result = subprocess.run(
+            ["bash", "-c", shell], text=True, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, env=environment, check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        arguments = capture.read_text().splitlines()
+        self.assertEqual(arguments.count("CALL"), 2)
+        self.assertEqual(arguments.count("ARG=--debug"), 2)
+
     def test_uninstall_and_forbidden_operations_absent_from_installer_paths(self):
         install_source = (ROOT / "scripts/install.sh").read_text()
         helper_source = SCRIPT.read_text()
@@ -563,6 +678,13 @@ class ApplyPolicyTests(unittest.TestCase):
         apply = source.index('apply_rp1_gpclk_dkms_installation "$debug" || return 1')
         self.assertLess(prepare, packages)
         self.assertLess(packages, apply)
+
+    def test_helper_invocations_use_exec_command_and_propagate_debug(self):
+        source = (ROOT / "scripts/install.sh").read_text()
+        self.assertNotRegex(source, r'if ! python3 "\$RP1_GPCLK_DKMS_HELPER"')
+        self.assertEqual(source.count('exec_command "Resolve RP1-GPCLK-DKMS installation plan"'), 1)
+        self.assertEqual(source.count('exec_command "Apply RP1-GPCLK-DKMS installation plan"'), 1)
+        self.assertGreaterEqual(source.count('args+=(--debug)'), 2)
 
     def test_explicit_true_reaches_planner_without_raspberry_pi_identity(self):
         source = (ROOT / "scripts/install.sh").read_text()

--- a/src/Makefile
+++ b/src/Makefile
@@ -1111,7 +1111,7 @@ $(BIN_DIR)/$(OUT): $(PROFILE_RELEASE_BIN) FORCE_PROFILE_BINARY
 .PHONY: semantics-test mailbox-memory-flag-test legacy-gpio-clock-model-test gpio-frequency-correction-test machine-power-control-test websocket-lifecycle-test wspr-band-catalog-test gpio-band-policy-test
 .PHONY: support-request-guard-test privileged-network-policy-test backend-http-guard-test websocket-upgrade-guard-test apache-privileged-network-policy-test privileged-network-transaction-test privileged-network-runtime-test privileged-network-runtime-wiring-test privileged-network-admin-test support-bundle-job-manager-test support-bundle-result-validator-test
 .PHONY: support-bundle-collector-executor-test support-bundle-runtime-test support-bundle-runtime-installer-test
-.PHONY: installer-dependency-test ui-publication-test support-bundle-age-dependency-test support-bundle-http-test support-bundle-web-server-wiring-test
+.PHONY: installer-dependency-test rp1-gpclk-dkms-installer-test ui-publication-test support-bundle-age-dependency-test support-bundle-http-test support-bundle-web-server-wiring-test
 .PHONY: support-bundle-download-file-test support-bundle-checksum-file-test support-bundle-archive-digest-test
 .PHONY: support-bundle-download-preparation-test support-bundle-job-directory-remover-test support-bundle-startup-cleanup-test
 .PHONY: support-bundle-private-artifact-test support-bundle-age-roundtrip-test support-bundle-key-provisioning-test
@@ -1329,6 +1329,9 @@ support-bundle-runtime-installer-test:
 
 installer-dependency-test:
 	$(Q)bash ../scripts/tests/installer_dependency_test.sh
+
+rp1-gpclk-dkms-installer-test:
+	$(Q)python3 ../scripts/tests/rp1_gpclk_dkms_install_test.py
 
 ui-publication-test:
 	$(Q)python3 ../scripts/tests/ui_publication_test.py


### PR DESCRIPTION
## Summary
- add automatic and explicit RP1-GPCLK-DKMS provider installation orchestration
- validate immutable release and exact-source development identities fail closed
- honor installer dry-run/debug through the standard command wrapper without invoking Python during dry-run
- preserve route-neutral, output-disabled, provider-preserving safety boundaries

## Validation
- bash syntax and ShellCheck warning-level checks
- Python compilation
- 40 offline RP1 installer contract tests
- installer dependency and Make integration target
- hardware-independent RP1 planner, lifecycle, transition, development policy, route runtime/service, and diagnostics tests
- direct and streamed installer entry-point parity

No target installation, module load, route/overlay change, GPIO operation, transmission, or RF activity was performed.