### PR TITLE
Clarify installer dry-run reporting

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,7 +8,10 @@ Set `DRY_RUN=true` to inspect the selected install or uninstall workflow
 without changing the checkout or system. Dry runs write no installer log,
 temporary merge output, staged executable, installed configuration, package,
 service, boot, web, GPIO, or provider state. Passing `debug` prints the planned
-commands to the console.
+commands to the console with shell-safe quoting that preserves exact argument
+boundaries. Successful dry runs end with an explicit notice that the selected
+plan completed without applying changes; they do not report an installation or
+uninstallation as completed.
 
 ## RP1-GPCLK-DKMS provider
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1872,6 +1872,20 @@ remove_slash() {
 }
 
 # -----------------------------------------------------------------------------
+# @brief Render command arguments with unambiguous Bash-safe quoting.
+# @param ... Command argv to render.
+# @return A single display-only string; no argument is evaluated.
+# -----------------------------------------------------------------------------
+render_command_argv() {
+    local arg quoted rendered=""
+    for arg in "$@"; do
+        printf -v quoted '%q' "$arg"
+        rendered+="${rendered:+ }${quoted}"
+    done
+    printf '%s' "$rendered"
+}
+
+# -----------------------------------------------------------------------------
 # @brief Executes a command in a separate Bash process.
 # @details This function manages the execution of a shell command, handling the
 #          display of status messages. It supports dry-run mode, where the
@@ -1924,12 +1938,12 @@ exec_command() {
     # Build the actual command array
     cmd=( "${args[@]}" )
 
-    # Join cmd[@] on spaces into one line
-    cmd_str=$(printf '%s ' "${cmd[@]}")
-    cmd_str=${cmd_str% }   # strip trailing space
+    # Render argv for display without losing argument boundaries or allowing
+    # shell metacharacters to look executable.
+    cmd_str=$(render_command_argv "${cmd[@]}")
     if [[ "$debug" == "debug" ]]; then
-        logD "Name:    $exec_name"
-        logD "Command: $cmd_str"
+        debug_print "Name:    $exec_name" "$debug"
+        debug_print "Command: $cmd_str" "$debug"
     fi
 
     # Prepare status prefixes
@@ -2088,7 +2102,10 @@ replace_string_in_script() {
     local replace_string="$3"
 
     if [[ "$DRY_RUN" == "true" ]]; then
-        logD "Exec: sed -i 's|%${search_string}%|${replace_string}|g' '$file_path'"
+        local planned_command
+        planned_command=$(render_command_argv \
+            sed -i "s|%${search_string}%|${replace_string}|g" "$file_path")
+        debug_print "Dry run command: $planned_command" "$debug"
         debug_end "$debug"
         return 0
     fi
@@ -6491,10 +6508,14 @@ upgrade_ini() {
     fi
 
     if [[ "$DRY_RUN" == "true" ]]; then
+        local planned_command
         if [[ -f "$old_ini" ]]; then
-            logD "Exec: cp -f '$old_ini' '$backup_ini'"
+            planned_command=$(render_command_argv cp -f "$old_ini" "$backup_ini")
+            debug_print "Dry run command: $planned_command" "$debug"
         fi
-        logD "Exec: merge '$old_ini' with '$new_ini' into '$merged_ini'"
+        debug_print \
+            "Dry run INI merge: old=$(printf '%q' "$old_ini") new=$(printf '%q' "$new_ini") output=$(printf '%q' "$merged_ini")" \
+            "$debug"
         debug_end "$debug"
         return 0
     fi
@@ -8158,6 +8179,22 @@ finish_script() {
         action_message="Installation"
     else
         action_message="Uninstallation"
+    fi
+
+    # Dry runs describe plan evaluation and return before any normal install or
+    # uninstall success message, URL, reboot reminder, or completion claim.
+    if [[ "$DRY_RUN" == "true" ]]; then
+        if [[ "$overall_status" -eq 0 ]]; then
+            debug_print "$action_message dry run completed successfully; no changes were applied." "$debug"
+            printf "\nDry run successful: %s %s plan completed; no changes were applied.\n" \
+                "$REPO_TITLE" "${action_message,,}"
+            debug_end "$debug"
+            return 0
+        fi
+        logE "$action_message dry run failed while evaluating the $REPO_TITLE plan."
+        debug_print "$action_message dry run encountered errors; no completion was claimed." "$debug"
+        debug_end "$debug"
+        return 1
     fi
 
     # Handle success or failure messages

--- a/scripts/tests/installer_dry_run_purity_test.py
+++ b/scripts/tests/installer_dry_run_purity_test.py
@@ -16,6 +16,15 @@ ROOT = Path(__file__).resolve().parents[2]
 INSTALLER = ROOT / "scripts" / "install.sh"
 
 
+def bash_quote(value: str | Path) -> str:
+    return subprocess.run(
+        ["bash", "-c", 'printf "%q" "$1"', "bash-quote", str(value)],
+        text=True,
+        stdout=subprocess.PIPE,
+        check=True,
+    ).stdout
+
+
 def snapshot(root: Path) -> dict[str, tuple[str, int, int, str]]:
     result: dict[str, tuple[str, int, int, str]] = {}
     for path in sorted((root, *root.rglob("*"))):
@@ -61,9 +70,11 @@ class InstallerDryRunPurityTest(unittest.TestCase):
         return result
 
     def test_upgrade_ini_dry_run_creates_nothing(self) -> None:
-        old_ini = self.root / "old.ini"
-        new_ini = self.root / "new.ini"
-        merged_ini = self.root / "merged.ini"
+        paths = self.root / "INI paths; $(not-executed)"
+        paths.mkdir()
+        old_ini = paths / "old config.ini"
+        new_ini = paths / "new config.ini"
+        merged_ini = paths / "merged config.ini"
         old_ini.write_text("[WSPR]\nCall Sign = OLD\n", encoding="utf-8")
         new_ini.write_text("[WSPR]\nCall Sign = NEW\n", encoding="utf-8")
         before = snapshot(self.root)
@@ -71,7 +82,6 @@ class InstallerDryRunPurityTest(unittest.TestCase):
         result = self.run_shell(
             r'''
 source "$INSTALLER"
-logD() { printf '%s\n' "$*"; }
 DRY_RUN=true
 upgrade_ini "$OLD_INI" "$NEW_INI" "$MERGED_INI" debug
 ''',
@@ -81,7 +91,13 @@ upgrade_ini "$OLD_INI" "$NEW_INI" "$MERGED_INI" debug
         )
 
         self.assertEqual(snapshot(self.root), before)
-        self.assertIn("Exec: merge", result.stdout)
+        expected_backup = f"Dry run command: cp -f {bash_quote(old_ini)} {bash_quote(f'{old_ini}.pre_migration.bak')}"
+        expected_merge = (
+            f"Dry run INI merge: old={bash_quote(old_ini)} "
+            f"new={bash_quote(new_ini)} output={bash_quote(merged_ini)}"
+        )
+        self.assertIn(expected_backup, result.stderr)
+        self.assertIn(expected_merge, result.stderr)
         self.assertFalse(merged_ini.exists())
         self.assertFalse(Path(f"{old_ini}.pre_migration.bak").exists())
 
@@ -110,7 +126,7 @@ upgrade_ini "$OLD_INI" "$NEW_INI" "$MERGED_INI" debug
         self.assertEqual(snapshot(self.root), before)
 
     def test_placeholder_replacement_is_display_only(self) -> None:
-        target = self.root / "installed.ini"
+        target = self.root / "installed $(not-executed); config.ini"
         target.write_text("version=%SEMANTIC_VERSION%\n", encoding="utf-8")
         target.chmod(0o640)
         before = snapshot(self.root)
@@ -118,15 +134,55 @@ upgrade_ini "$OLD_INI" "$NEW_INI" "$MERGED_INI" debug
         result = self.run_shell(
             r'''
 source "$INSTALLER"
-logD() { printf '%s\n' "$*"; }
 DRY_RUN=true
-replace_string_in_script "$TARGET" SEMANTIC_VERSION v9.9.9 debug
+replace_string_in_script "$TARGET" SEMANTIC_VERSION 'v9.9.9; $(not-executed)' debug
 ''',
             TARGET=target,
         )
 
         self.assertEqual(snapshot(self.root), before)
-        self.assertIn("Exec: sed -i", result.stdout)
+        replacement = "v9.9.9; $(not-executed)"
+        expected = "Dry run command: " + " ".join(
+            bash_quote(value)
+            for value in (
+                "sed",
+                "-i",
+                f"s|%SEMANTIC_VERSION%|{replacement}|g",
+                target,
+            )
+        )
+        self.assertIn(expected, result.stderr)
+
+    def test_exec_command_debug_renders_exact_safe_argv_without_execution(self) -> None:
+        sentinel = self.root / "command-invoked"
+        before = snapshot(self.root)
+        arguments = (
+            "plain",
+            "two words",
+            "$(not-executed)",
+            "semi;colon",
+            "single'quote",
+            "line\nbreak",
+            "debug",
+        )
+        result = self.run_shell(
+            r'''
+source "$INSTALLER"
+probe() { printf invoked >"$SENTINEL"; return 99; }
+DRY_RUN=true
+FGGLD= RESET= FGGRN= FGRED= MOVE_UP= CLEAR_LINE=
+exec_command "argv display" probe plain "two words" '$(not-executed)' 'semi;colon' \
+    "single'quote" $'line\nbreak' debug debug
+''',
+            SENTINEL=sentinel,
+        )
+        self.assertEqual(snapshot(self.root), before)
+        expected = "Command: " + " ".join(
+            bash_quote(value) for value in ("probe", *arguments)
+        )
+        self.assertIn("Name:    argv display", result.stderr)
+        self.assertIn(expected, result.stderr)
+        self.assertFalse(sentinel.exists())
 
     def test_placeholder_replacement_allows_planned_new_target(self) -> None:
         target = self.root / "not-installed-yet.ini"
@@ -264,6 +320,67 @@ set_time debug
             SENTINEL=sentinel,
         )
         self.assertEqual(snapshot(self.root), before)
+
+    def test_finish_script_reports_install_and_uninstall_as_dry_runs(self) -> None:
+        for action in ("install", "uninstall"):
+            result = self.run_shell(
+                r'''
+source "$INSTALLER"
+DRY_RUN=true
+ACTION="$REQUESTED_ACTION"
+REPO_TITLE='Wsprry Pi'
+finish_script 0 debug
+''',
+                REQUESTED_ACTION=action,
+            )
+            self.assertIn(
+                f"Dry run successful: Wsprry Pi {action}ation plan completed; no changes were applied.",
+                result.stdout,
+            )
+            self.assertNotIn("Installation successful", result.stdout)
+            self.assertNotIn("Uninstallation successful", result.stdout)
+            self.assertNotIn("has been uninstalled", result.stdout)
+            self.assertNotIn("To configure", result.stdout)
+
+    def test_normal_finish_message_is_unchanged(self) -> None:
+        result = self.run_shell(
+            r'''
+source "$INSTALLER"
+hostname() { if [[ "${1:-}" == -I ]]; then printf '127.0.0.1\n'; else command hostname "$@"; fi; }
+DRY_RUN=false
+ACTION=install
+NO_WEB=true
+REPO_TITLE='Wsprry Pi'
+finish_script 0
+'''
+        )
+        self.assertIn("Installation successful: Wsprry Pi.", result.stdout)
+        self.assertNotIn("Dry run successful", result.stdout)
+
+    def test_failed_dry_run_never_claims_completion(self) -> None:
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                r'''
+source "$INSTALLER"
+logE() { printf '%s\n' "$1" >&2; }
+DRY_RUN=true
+ACTION=install
+REPO_TITLE='Wsprry Pi'
+finish_script 1 debug
+''',
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={**os.environ, "INSTALLER": str(INSTALLER)},
+            check=False,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Installation dry run failed", result.stderr)
+        self.assertNotIn("successful", result.stdout.lower())
+        self.assertNotIn("completed", result.stdout.lower())
 
     def test_direct_mutation_paths_have_dry_run_guards(self) -> None:
         source = INSTALLER.read_text(encoding="utf-8")

--- a/scripts/tests/rp1_gpclk_dkms_install_test.py
+++ b/scripts/tests/rp1_gpclk_dkms_install_test.py
@@ -612,8 +612,8 @@ INSTALL_RP1_GPCLK_DKMS=true
 RP1_GPCLK_DKMS_SOURCE="$SOURCE_SELECTOR"
 REPO_BRANCH="$WSPRRYPi_BRANCH"
 FGGLD= RESET= FGGRN= FGRED= MOVE_UP= CLEAR_LINE=
-prepare_rp1_gpclk_dkms_installation
-apply_rp1_gpclk_dkms_installation
+prepare_rp1_gpclk_dkms_installation debug
+apply_rp1_gpclk_dkms_installation debug
 [[ ! -e "$SENTINEL" ]]
 cleanup_rp1_gpclk_dkms_state
 [[ -z "$RP1_GPCLK_DKMS_STATE_DIR" && -z "$RP1_GPCLK_DKMS_HELPER" ]]
@@ -634,6 +634,18 @@ cleanup_rp1_gpclk_dkms_state
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertFalse(sentinel.exists())
             self.assertEqual(result.stdout.count("(dry)"), 4)
+            self.assertIn("Name:    Resolve RP1-GPCLK-DKMS installation plan", result.stderr)
+            self.assertIn("Name:    Apply RP1-GPCLK-DKMS installation plan", result.stderr)
+            helper = install_script.parent / "rp1_gpclk_dkms_install.py"
+            prepare_command = (
+                f"Command: python3 {helper} prepare --state-dir dry-run:no-state-created "
+                f"--install true --source {selector} --wsprry-source {branch} --dry-run --debug"
+            )
+            apply_command = (
+                f"Command: python3 {helper} apply --state-dir dry-run:no-state-created --debug"
+            )
+            self.assertIn(prepare_command, result.stderr)
+            self.assertIn(apply_command, result.stderr)
 
     def test_exec_command_preserves_internal_debug_argv(self):
         install_script = ROOT / "scripts" / "install.sh"


### PR DESCRIPTION
## Summary
- report dry-run completion instead of installation success
- show exact RP1 helper argv in debug dry runs
- show explicit planned INI merge and replacement commands
- retain mutation-free dry-run behavior

## Validation
- installer dry-run regression coverage
- shell syntax and whitespace checks
- live dry-run behavior examined on wspr5 before merge