### PR TITLE
Remove only WsprryPi-owned RP1 providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,14 @@ independently maintained `/dev/rp1-gpclk` provider. On Pi 5-family systems the
 installer can resolve and validate an eligible published provider release; it
 also supports fail-closed exact-source development selection. See the
 [RP1-GPCLK-DKMS installation contract](docs/rp1-gpclk-dkms-installation.md).
-WsprryPi preserves the provider on uninstall and never selects a route, loads
-the module, or enables output as part of provider installation. Runtime checks
-establish application compatibility only; they do not qualify installation,
-GPIO behavior, timing, frequency accuracy, spectral performance, or RF output.
+On uninstall, WsprryPi removes only an unchanged provider that its secure v2
+ownership record proves WsprryPi installed; all pre-existing, legacy-recorded,
+ambiguous, or drifted providers are preserved. Operators can set
+`REMOVE_RP1_GPCLK_DKMS=false` to retain even a proven owned provider. WsprryPi
+never selects a route, loads the module, or enables output as part of provider
+installation. Runtime checks establish application compatibility only; they do
+not qualify installation, GPIO behavior, timing, frequency accuracy, spectral
+performance, or RF output.
 
 ## Installation
 

--- a/docs/research/issue-412-rp1-gpclk-dkms-integration.md
+++ b/docs/research/issue-412-rp1-gpclk-dkms-integration.md
@@ -49,9 +49,14 @@ The package installs both overlays and leaves both inactive. The installer does
 not edit config.txt, load the module, apply an overlay, or silently substitute a
 route. A route change therefore does not reinstall the package.
 
-WsprryPi uninstallation preserves the independently owned package by default.
-An explicit REMOVE_RP1_GPCLK_DKMS=true with ACTION=uninstall removes only the
-recognized 1.0.0-1 Debian package through APT.
+WsprryPi uninstallation removes a provider only when its secure v2 ownership
+record proves that WsprryPi installed the unchanged, inactive identity. It
+preserves pre-existing providers, legacy or missing records, and ambiguous or
+drifted state. Release removal uses the ordinary Debian package lifecycle;
+exact-source development removal uses its captured upstream rollback record and
+entrypoint. `REMOVE_RP1_GPCLK_DKMS=false` preserves even a proven owned provider;
+`true` expresses removal intent but does not force removal through a failed
+ownership or safety check.
 
 ## Runtime fail-closed boundary
 

--- a/docs/rp1-gpclk-dkms-installation.md
+++ b/docs/rp1-gpclk-dkms-installation.md
@@ -72,7 +72,8 @@ manifest are not eligible.
 An exact installed release is verified idempotently. Foreign, mixed,
 development, active, enrolled, manager-bound, or different-version state is
 refused and must be handled by its owning migration or recovery procedure.
-WsprryPi uninstall preserves the provider.
+An exact release that was already present is accepted but never claimed as
+WsprryPi-owned.
 
 ## Development sources
 
@@ -105,8 +106,62 @@ external command argv and captured validation output. The resolved plan and
 ordinary package/DKMS or upstream lifecycle output remain visible during a real
 installation even when debug mode is off.
 
-After successful verification, current provider identity is recorded at
-`/var/lib/wsprrypi/rp1-gpclk-dkms-installation.json`. This record describes
-source/package state only. It is not a signature, route selection, hardware or
-kernel qualification, GPIO permission, transmission authority, or RF evidence.
-No failure selects a fallback backend.
+Only when WsprryPi actually mutates an empty provider state and then verifies
+the result does it atomically create the root-owned, mode-0600 v2 ownership
+record at
+`/var/lib/wsprrypi/rp1-gpclk-dkms-installation.json`. A release record embeds
+the validated release manifest and hashes every DKMS module artifact present at
+ownership creation. Later DKMS artifacts for additional kernels are accepted
+only at canonical module paths with the same recorded module version; every
+originally recorded artifact must remain byte-identical.
+A development record binds the exact source, kernel, installed module,
+upstream evidence, rollback record, and captured upstream rollback entrypoint.
+Failed installs and dry runs create no ownership record. A stale record blocks
+a new provider installation rather than being overwritten.
+
+The record proves only that this WsprryPi workflow installed the recorded
+provider identity. It is not a signature, route selection, hardware or kernel
+qualification, GPIO permission, transmission authority, or RF evidence. The
+older v1 installation record did not distinguish a newly installed provider
+from an idempotently accepted pre-existing provider, so it is deliberately
+insufficient for automatic removal.
+
+## Ownership-aware uninstall
+
+After WsprryPi application and service teardown, uninstall checks the v2
+ownership record. Missing, legacy, malformed, symlinked, insecure, foreign,
+mixed, active, configured, enrolled, manager-bound, or identity-drifted state
+is preserved with an operator-facing reason. A matching release is revalidated
+against its complete recorded manifest and module-artifact hashes, then removed
+with the normal Debian package lifecycle. A matching development installation
+is removed only through the exact upstream `development-rollback` entrypoint
+and rollback record captured during installation. WsprryPi never invents a
+direct DKMS, module unload, overlay, route, boot, service, GPIO, or RF removal
+sequence.
+
+The ownership record is deleted only after the canonical removal succeeds and
+the helper verifies that package, DKMS, source, module, overlay, route,
+enrollment, and manager state are absent. A lifecycle failure retains the
+record, fails the overall uninstall, and leaves recovery to the recorded owning
+procedure. Successfully rolled-back development evidence remains under
+`/var/lib/wsprrypi` as uniquely named audit/recovery evidence and does not block
+a later installation.
+
+`REMOVE_RP1_GPCLK_DKMS` accepts exactly:
+
+- `auto` (default): remove only a matching, inactive provider proven by the v2
+  ownership record;
+- `true`: explicitly request the same ownership-aware removal; it does not
+  bypass any provenance, identity, inactivity, or upstream lifecycle check; or
+- `false`: preserve the provider even when WsprryPi ownership is proven.
+
+For example, to remove WsprryPi while deliberately retaining an owned provider:
+
+```sh
+sudo ACTION=uninstall REMOVE_RP1_GPCLK_DKMS=false ./scripts/install.sh
+```
+
+`DRY_RUN=true ACTION=uninstall` passes the planned helper argv through the
+standard command wrapper, does not start Python, and does not inspect or mutate
+provider or ownership state. Debug mode displays the exact `remove --debug`
+argv. No failure selects a fallback backend.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,7 +18,7 @@ uninstallation as completed.
 `install.sh` uses `rp1_gpclk_dkms_install.py` to resolve and validate the
 independently owned provider before package mutation. Automatic Pi 5/CM5,
 explicit override/opt-out, published release, immutable development source,
-dry-run, existing-state refusal, and provider-preserving uninstall behavior are
+dry-run, existing-state refusal, and ownership-aware uninstall behavior are
 documented in [RP1-GPCLK-DKMS installation](../docs/rp1-gpclk-dkms-installation.md).
 Dry-run uses the installer's standard command wrapper and never starts the
 Python helper. Passing `debug` displays the helper command and, for a real run,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -225,6 +225,7 @@ declare UI_PUBLICATION_ATTEMPTED="false"
 declare UI_PUBLICATION_RESULT_FILE=""
 declare INSTALL_RP1_GPCLK_DKMS="${INSTALL_RP1_GPCLK_DKMS:-auto}"
 declare RP1_GPCLK_DKMS_SOURCE="${RP1_GPCLK_DKMS_SOURCE:-auto}"
+declare REMOVE_RP1_GPCLK_DKMS="${REMOVE_RP1_GPCLK_DKMS:-auto}"
 declare RP1_GPCLK_DKMS_STATE_DIR=""
 declare RP1_GPCLK_DKMS_HELPER=""
 
@@ -2369,6 +2370,76 @@ apply_rp1_gpclk_dkms_installation() {
         warn "RP1-GPCLK-DKMS installation failed closed; inspect the retained installer log and provider state."
         return 1
     fi
+    debug_end "$debug"
+    return 0
+}
+
+# -----------------------------------------------------------------------------
+# @brief Remove an unchanged RP1 provider only when a v2 record proves that
+#        WsprryPi installed it.
+# @details The helper preserves missing, legacy, malformed, drifted, active, or
+#          otherwise ambiguous provider state. Release removal uses the normal
+#          Debian package lifecycle; development removal uses the exact
+#          upstream rollback entrypoint captured at installation time.
+# -----------------------------------------------------------------------------
+remove_owned_rp1_gpclk_dkms_provider() {
+    local debug
+    debug=$(debug_start "$@")
+    eval set -- "$(debug_filter "$@")"
+
+    [[ "$ACTION" == "uninstall" ]] || return 0
+    case "$REMOVE_RP1_GPCLK_DKMS" in
+        auto|true|false) ;;
+        *)
+            warn "REMOVE_RP1_GPCLK_DKMS must be auto, true, or false."
+            return 1
+            ;;
+    esac
+    if [[ "$REMOVE_RP1_GPCLK_DKMS" == "false" ]]; then
+        logI "RP1-GPCLK-DKMS preserved by explicit operator opt-out."
+        debug_end "$debug"
+        return 0
+    fi
+
+    local script_source="${BASH_SOURCE[0]:-}"
+    local local_helper=""
+    if [[ -n "$script_source" && "$script_source" != "bash" ]]; then
+        local_helper="$(cd "$(dirname "$script_source")" && pwd -P)/rp1_gpclk_dkms_install.py"
+    fi
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        RP1_GPCLK_DKMS_STATE_DIR="dry-run:no-state-created"
+        RP1_GPCLK_DKMS_HELPER="${local_helper:-dry-run:no-helper-downloaded}"
+    else
+        RP1_GPCLK_DKMS_STATE_DIR=$(mktemp -d /tmp/wsprrypi-rp1-gpclk-dkms.XXXXXX)
+        chmod 0700 "$RP1_GPCLK_DKMS_STATE_DIR"
+        RP1_GPCLK_DKMS_HELPER="$RP1_GPCLK_DKMS_STATE_DIR/rp1_gpclk_dkms_install.py"
+        if [[ -n "$local_helper" && -f "$local_helper" && ! -L "$local_helper" ]]; then
+            cp -- "$local_helper" "$RP1_GPCLK_DKMS_HELPER"
+            chmod 0700 "$RP1_GPCLK_DKMS_HELPER"
+        else
+            local helper_url="${GIT_RAW_BASE}/${REPO_ORG}/${REPO_NAME}/${REPO_BRANCH}/scripts/rp1_gpclk_dkms_install.py"
+            if ! curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
+                --output "$RP1_GPCLK_DKMS_HELPER" "$helper_url"; then
+                warn "Unable to retrieve the RP1-GPCLK-DKMS installer helper from $helper_url."
+                cleanup_rp1_gpclk_dkms_state
+                return 1
+            fi
+            chmod 0700 "$RP1_GPCLK_DKMS_HELPER"
+        fi
+    fi
+
+    local remove_args=(remove --remove "$REMOVE_RP1_GPCLK_DKMS")
+    if [[ "$debug" == "debug" ]]; then
+        remove_args+=(--debug)
+    fi
+    if ! EXEC_COMMAND_SHOW_OUTPUT=true exec_command "Remove WsprryPi-owned RP1-GPCLK-DKMS provider when ownership and identity match" \
+        python3 "$RP1_GPCLK_DKMS_HELPER" "${remove_args[@]}" "$debug"; then
+        warn "RP1-GPCLK-DKMS owned-provider removal failed; the ownership record was retained for recovery."
+        cleanup_rp1_gpclk_dkms_state
+        return 1
+    fi
+    cleanup_rp1_gpclk_dkms_state
     debug_end "$debug"
     return 0
 }
@@ -8237,8 +8308,9 @@ finish_script() {
             printf "Remember to reboot to disable your soundcard before transmission.\n\n"
         fi
     elif [[ "$ACTION" == "uninstall" && "$overall_status" -eq 0 ]]; then
-        printf "\n%s has been uninstalled. No apt packages have\n" "$REPO_TITLE"
-        printf "been removed to prevent impact to other functionality.\n\n"
+        printf "\n%s has been uninstalled. Shared apt packages were retained.\n" "$REPO_TITLE"
+        printf "An unchanged RP1-GPCLK-DKMS provider is removed only when\n"
+        printf "WsprryPi's v2 ownership record proves it installed that provider.\n\n"
         if [[ "${REBOOT:-false}" == "true" ]]; then
             printf "Remember to reboot to re-enable your soundcard.\n\n"
         fi
@@ -8351,6 +8423,9 @@ manage_wsprry_pi() {
         )
         # Re-add manage_sound at the very end
         group_to_execute+=("manage_sound")
+        # Perform ownership-aware provider cleanup only after application and
+        # service teardown has completed.
+        group_to_execute+=("remove_owned_rp1_gpclk_dkms_provider")
         ;;
     *)
         die 1 "Invalid action: '$ACTION'. Use 'install' or 'uninstall'."
@@ -8383,6 +8458,10 @@ manage_wsprry_pi() {
                 restore_daemon_state "${func}" "${debug}"
                 overall_status=1
                 break
+            elif [[ "$function_name" == "remove_owned_rp1_gpclk_dkms_provider" ]]; then
+                # Do not report uninstall success after a partially completed
+                # provider lifecycle. Its ownership record remains for recovery.
+                overall_status=1
             fi
         else
             debug_print "$func succeeded." "$debug"

--- a/scripts/rp1_gpclk_dkms_install.py
+++ b/scripts/rp1_gpclk_dkms_install.py
@@ -14,6 +14,7 @@ import os
 import pathlib
 import platform
 import re
+import secrets
 import shlex
 import stat
 import subprocess
@@ -38,7 +39,8 @@ PACKAGE_NAME = "rp1-gpclk-dkms"
 DKMS_NAME = "rp1-gpclk-dkms"
 MODULE_NAME = "rp1_gpclk_dkms"
 COMPATIBILITY_IDENTITY = "v0.9.0-pi5"
-RECORD_SCHEMA = "wsprrypi-rp1-gpclk-dkms-installation-v1"
+LEGACY_RECORD_SCHEMA = "wsprrypi-rp1-gpclk-dkms-installation-v1"
+RECORD_SCHEMA = "wsprrypi-rp1-gpclk-dkms-ownership-v2"
 STATE_SCHEMA = "wsprrypi-rp1-gpclk-dkms-plan-v1"
 SUPPORTED_UAPI_MIN = 4
 SUPPORTED_UAPI_MAX = 4
@@ -53,6 +55,7 @@ MAX_PACKAGE_MEMBERS = 20000
 MAX_PACKAGE_MEMBER_BYTES = 64 * 1024 * 1024
 MAX_EXPANDED_TAR_BYTES = 512 * 1024 * 1024
 MAX_ARCHIVE_PATH_BYTES = 1024
+MAX_RECORD_BYTES = 4 * 1024 * 1024
 
 
 class ContractError(RuntimeError):
@@ -751,6 +754,136 @@ def atomic_json(path: pathlib.Path, value: Any, mode: int = 0o600) -> None:
             pass
 
 
+def atomic_json_new(path: pathlib.Path, value: Any, mode: int = 0o600) -> None:
+    """Publish a new ownership record without replacing any concurrent state."""
+    payload = canonical(value) + b"\n"
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.fchmod(descriptor, mode)
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.link(temporary, path, follow_symlinks=False)
+        parent_descriptor = os.open(path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            os.fsync(parent_descriptor)
+        finally:
+            os.close(parent_descriptor)
+    except FileExistsError as error:
+        raise ContractError("installation ownership record appeared during provider installation") from error
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def record_file_identity(path: pathlib.Path) -> os.stat_result:
+    require(path.is_absolute(), "installation ownership record path must be absolute")
+    secure_record_parent(path)
+    try:
+        info = path.lstat()
+    except FileNotFoundError as error:
+        raise ContractError("installation ownership record is absent") from error
+    require(stat.S_ISREG(info.st_mode), "installation ownership record is not a regular file")
+    require(info.st_uid == os.geteuid(), "installation ownership record is not owned by the invoking user")
+    require(stat.S_IMODE(info.st_mode) & 0o077 == 0, "installation ownership record is accessible by group or others")
+    require(info.st_size <= MAX_RECORD_BYTES, "installation ownership record exceeds the bounded size")
+    return info
+
+
+def load_ownership_record(path: pathlib.Path) -> tuple[dict[str, Any] | None, os.stat_result | None, str | None]:
+    """Return a validated v2 record, or a preservation reason without following unsafe state."""
+    if not path.is_absolute():
+        return None, None, "ownership record path is not absolute"
+    if not path.exists() and not path.is_symlink():
+        return None, None, "no WsprryPi ownership record exists"
+    try:
+        info = record_file_identity(path)
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        try:
+            opened = os.fstat(descriptor)
+            require(
+                (opened.st_dev, opened.st_ino) == (info.st_dev, info.st_ino),
+                "installation ownership record changed while opening",
+            )
+            with os.fdopen(descriptor, "rb", closefd=False) as stream:
+                payload = stream.read(MAX_RECORD_BYTES + 1)
+        finally:
+            os.close(descriptor)
+        require(len(payload) <= MAX_RECORD_BYTES, "installation ownership record exceeds the bounded size")
+        value = json.loads(payload.decode("utf-8"))
+        require(isinstance(value, dict), "installation ownership record is not an object")
+        if value.get("schema") == LEGACY_RECORD_SCHEMA:
+            return None, info, "legacy v1 installation record cannot prove WsprryPi ownership"
+        require(value.get("schema") == RECORD_SCHEMA, "installation ownership record schema is unsupported")
+        common = {
+            "schema", "repository", "owner", "channel", "installationMethod",
+            "routeActivation", "output", "qualificationClaim",
+        }
+        channel = value.get("channel")
+        if channel == "release":
+            required = common | {"tag", "sourceCommit", "manifest", "moduleArtifacts"}
+        elif channel == "development":
+            required = common | {
+                "sourceCommit", "productVersion", "sourceTree", "uapiSha256",
+                "versionSource", "versionSourceSha256", "targetKernel",
+                "compatibilityIdentity", "upstreamEvidence", "rollbackRecord",
+                "rollbackRecordSha256", "rollbackEntrypoint",
+                "rollbackEntrypointSha256", "installedModulePath",
+                "installedModuleSha256", "decompressedModuleSha256",
+            }
+        else:
+            raise ContractError("installation ownership record channel is unsupported")
+        require_exact_keys(value, required, "installation ownership record")
+        require(value["repository"] == REPOSITORY, "installation ownership repository differs")
+        require(value["owner"] == "WsprryPi", "installation ownership owner differs")
+        require(value["routeActivation"] == "disabled" and value["output"] == "disabled", "installation ownership record is not route-neutral")
+        require(value["qualificationClaim"] is False, "installation ownership record contains an unsupported qualification claim")
+        if channel == "release":
+            require(isinstance(value["tag"], str) and isinstance(value["sourceCommit"], str), "release ownership identity fields are invalid")
+            require(isinstance(value["manifest"], dict) and isinstance(value["moduleArtifacts"], list), "release ownership evidence fields are invalid")
+        else:
+            string_fields = required - common
+            require(all(isinstance(value[field], str) for field in string_fields), "development ownership evidence fields are invalid")
+        return value, info, None
+    except (ContractError, OSError, UnicodeError, json.JSONDecodeError) as error:
+        return None, None, str(error)
+
+
+def remove_ownership_record(path: pathlib.Path, expected: os.stat_result) -> None:
+    current = record_file_identity(path)
+    require(
+        (current.st_dev, current.st_ino) == (expected.st_dev, expected.st_ino),
+        "installation ownership record changed during provider removal",
+    )
+    path.unlink()
+    parent_descriptor = os.open(path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(parent_descriptor)
+    finally:
+        os.close(parent_descriptor)
+
+
+def module_artifacts(root: pathlib.Path) -> list[dict[str, str]]:
+    base = root_path(root, "/lib/modules")
+    artifacts: list[dict[str, str]] = []
+    if not base.exists():
+        return artifacts
+    for path in sorted(base.glob("*/updates/dkms/rp1_gpclk_dkms.ko*")):
+        relative = pathlib.PurePosixPath("/" + str(path.relative_to(root)))
+        installed = installed_member(root, str(relative).removeprefix("/"), "file")
+        artifacts.append({"path": str(relative), "sha256": sha256_file(installed)})
+    return artifacts
+
+
+def ensure_new_ownership_record(path: pathlib.Path) -> None:
+    require(path.is_absolute(), "installation ownership record path must be absolute")
+    secure_record_parent(path)
+    require(not path.exists() and not path.is_symlink(), "stale installation ownership state blocks a new provider installation")
+
+
 def render_plan(plan: Mapping[str, Any]) -> None:
     print("RP1-GPCLK-DKMS installation plan")
     print(f"  WsprryPi source channel: {plan['wsprryChannel']}")
@@ -919,31 +1052,35 @@ def apply_release(state_dir: pathlib.Path, resolved: Mapping[str, Any], record: 
     require(not inventory["configuredRoute"], "a configured RP1 GPCLK route blocks ordinary installation")
     require(not inventory["enrollment"] and not inventory["developmentManager"], "development enrollment or manager binding blocks release installation")
     expected = manifest["debianVersion"]
+    installed_by_wsprrypi = False
     if inventory["packageVersion"] is None:
         require(
             not inventory["dkms"] and not inventory["sourceTrees"]
             and not inventory["moduleCandidates"] and not inventory["installedOverlays"],
             "foreign or mixed RP1 GPCLK installation blocks package installation",
         )
+        ensure_new_ownership_record(record)
         runner.run(
             ["apt-get", "install", "--no-install-recommends", "-y", str(package_path)],
             passthrough=True,
         )
+        installed_by_wsprrypi = True
     elif inventory["packageVersion"] == expected:
         pass
     else:
         raise ContractError(f"existing RP1-GPCLK-DKMS {inventory['packageVersion']} requires its owning package migration workflow; automatic replacement refused")
     verify_installed_release(root, manifest, runner)
-    record_value = {
-        "schema": RECORD_SCHEMA, "repository": REPOSITORY, "channel": "release",
-        "tag": resolved["tag"], "sourceCommit": resolved["commit"],
-        "productVersion": manifest["productVersion"], "debianVersion": manifest["debianVersion"],
-        "packageSha256": manifest["package"]["sha256"], "uapiSha256": manifest["uapi"]["sha256"],
-        "administrationProtocol": manifest["administrationProtocol"], "routeActivation": "disabled",
-        "output": "disabled", "qualificationClaim": False,
-    }
-    record.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    atomic_json(record, record_value)
+    if installed_by_wsprrypi:
+        artifacts = module_artifacts(root)
+        require(bool(artifacts), "installed release lacks attributable DKMS module artifacts")
+        atomic_json_new(record, {
+            "schema": RECORD_SCHEMA, "repository": REPOSITORY, "owner": "WsprryPi",
+            "channel": "release", "installationMethod": "debian-package",
+            "tag": resolved["tag"], "sourceCommit": resolved["commit"],
+            "manifest": manifest, "moduleArtifacts": artifacts,
+            "routeActivation": "disabled", "output": "disabled",
+            "qualificationClaim": False,
+        })
 
 
 def verify_development_result(
@@ -1016,8 +1153,9 @@ def apply_development(resolved: Mapping[str, Any], record: pathlib.Path, runner:
         and not before["developmentManager"],
         "an existing packaged, development, foreign, or mixed RP1 GPCLK installation requires its owning migration workflow",
     )
-    evidence = record.parent / "rp1-gpclk-dkms-development-evidence"
-    evidence.mkdir(parents=True, exist_ok=False, mode=0o700)
+    ensure_new_ownership_record(record)
+    evidence = record.parent / f"rp1-gpclk-dkms-development-evidence.{secrets.token_hex(12)}"
+    require(not evidence.exists() and not evidence.is_symlink(), "development evidence destination already exists")
     command = [
         str(source / "scripts" / "development-install"), "--source", str(source),
         "--kernel", platform.release(),
@@ -1029,18 +1167,192 @@ def apply_development(resolved: Mapping[str, Any], record: pathlib.Path, runner:
     require(not after["activeModule"], "RP1 GPCLK module became active during development installation")
     require(not after["configuredRoute"], "RP1 GPCLK route became configured during development installation")
     installed = result["installedModule"]
-    atomic_json(record, {
-        "schema": RECORD_SCHEMA, "repository": REPOSITORY, "channel": "development",
+    rollback_record = pathlib.Path(str(result.get("rollbackRecord", "")))
+    expected_rollback = evidence / "ROLLBACK.json"
+    require(rollback_record == expected_rollback and rollback_record.is_file() and not rollback_record.is_symlink(), "upstream development rollback record is missing or out of scope")
+    rollback_entrypoint = evidence / "rendered-source" / "scripts" / "development-rollback"
+    require(rollback_entrypoint.is_file() and not rollback_entrypoint.is_symlink(), "upstream development rollback entrypoint is missing or substituted")
+    installed_path = pathlib.Path(str(installed.get("installedPath", "")))
+    expected_prefix = pathlib.Path(f"/lib/modules/{platform.release()}/updates/dkms")
+    require(installed_path.is_absolute() and installed_path.parent == expected_prefix, "upstream installed module path is outside the exact-kernel DKMS destination")
+    atomic_json_new(record, {
+        "schema": RECORD_SCHEMA, "repository": REPOSITORY, "owner": "WsprryPi",
+        "channel": "development", "installationMethod": "upstream-development-rollback",
         "sourceCommit": resolved["commit"], "productVersion": resolved["version"],
         "sourceTree": resolved["sourceTree"], "uapiSha256": resolved["uapiSha256"],
         "versionSource": resolved["versionSource"],
         "versionSourceSha256": resolved["versionSourceSha256"],
         "installedModuleSha256": installed["installedFileSha256"],
         "decompressedModuleSha256": installed["decompressedElfSha256"],
+        "installedModulePath": str(installed_path),
         "targetKernel": platform.release(),
         "compatibilityIdentity": COMPATIBILITY_IDENTITY, "routeActivation": "disabled",
         "output": "disabled", "qualificationClaim": False, "upstreamEvidence": str(evidence),
+        "rollbackRecord": str(rollback_record), "rollbackRecordSha256": sha256_file(rollback_record),
+        "rollbackEntrypoint": str(rollback_entrypoint),
+        "rollbackEntrypointSha256": sha256_file(rollback_entrypoint),
     })
+
+
+def require_hash(value: Any, field: str) -> str:
+    require(isinstance(value, str) and SHA256.fullmatch(value) is not None, f"installation ownership record has invalid {field}")
+    return value
+
+
+def validate_recorded_module_artifacts(value: Any) -> list[dict[str, str]]:
+    require(isinstance(value, list) and value, "installation ownership record lacks module artifacts")
+    result: list[dict[str, str]] = []
+    for item in value:
+        require(isinstance(item, dict), "installation ownership module artifact is not an object")
+        require_exact_keys(item, {"path", "sha256"}, "installation ownership module artifact")
+        path = item["path"]
+        require(
+            isinstance(path, str)
+            and re.fullmatch(r"/lib/modules/[^/]+/updates/dkms/rp1_gpclk_dkms\.ko(?:\.(?:xz|gz|zst|bz2))?", path) is not None,
+            "installation ownership module artifact path is out of scope",
+        )
+        result.append({"path": path, "sha256": require_hash(item["sha256"], "module artifact SHA-256")})
+    require(len({item["path"] for item in result}) == len(result), "installation ownership module artifacts contain duplicate paths")
+    return sorted(result, key=lambda item: item["path"])
+
+
+def validate_release_removal(record: Mapping[str, Any], root: pathlib.Path, runner: Runner) -> None:
+    require(record["installationMethod"] == "debian-package", "release ownership installation method differs")
+    tag = record["tag"]
+    commit = record["sourceCommit"]
+    require(isinstance(tag, str) and SEMVER.fullmatch(tag) is not None, "release ownership tag is invalid")
+    require(isinstance(commit, str) and SHA40.fullmatch(commit) is not None, "release ownership commit is invalid")
+    manifest = record["manifest"]
+    require(isinstance(manifest, dict), "release ownership manifest is invalid")
+    validated = validate_manifest(manifest, tag=tag, tag_commit=commit)
+    verify_installed_release(root, validated, runner)
+    expected = {item["path"]: item["sha256"] for item in validate_recorded_module_artifacts(record["moduleArtifacts"])}
+    current = {item["path"]: item["sha256"] for item in module_artifacts(root)}
+    require(all(current.get(path) == digest for path, digest in expected.items()), "recorded DKMS module artifacts differ from WsprryPi ownership")
+    for path in current:
+        match = re.fullmatch(r"/lib/modules/([^/]+)/updates/dkms/rp1_gpclk_dkms\.ko(?:\.(?:xz|gz|zst|bz2))?", path)
+        require(match is not None, "installed DKMS module artifact path is out of scope")
+        version = runner.run(["modinfo", "-k", match.group(1), "-F", "version", MODULE_NAME]).stdout.strip()
+        require(version == validated["productVersion"], "additional-kernel DKMS module identity differs from WsprryPi ownership")
+
+
+def secure_owned_path(path: pathlib.Path, parent: pathlib.Path, description: str) -> pathlib.Path:
+    require(path.is_absolute(), f"{description} path is not absolute")
+    absolute = pathlib.Path(os.path.abspath(path))
+    parent_absolute = pathlib.Path(os.path.abspath(parent))
+    require(absolute.is_relative_to(parent_absolute), f"{description} path is outside WsprryPi-owned evidence")
+    try:
+        resolved = absolute.resolve(strict=True)
+    except OSError as error:
+        raise ContractError(f"{description} is unavailable") from error
+    require(resolved == absolute and resolved.is_file() and not resolved.is_symlink(), f"{description} is missing or substituted")
+    info = resolved.stat()
+    require(info.st_uid == os.geteuid(), f"{description} is not owned by the invoking user")
+    require(stat.S_IMODE(info.st_mode) & 0o022 == 0, f"{description} is group- or world-writable")
+    return resolved
+
+
+def validate_development_removal(record: Mapping[str, Any], root: pathlib.Path, runner: Runner) -> tuple[pathlib.Path, pathlib.Path]:
+    require(record["installationMethod"] == "upstream-development-rollback", "development ownership installation method differs")
+    require(isinstance(record["sourceCommit"], str) and SHA40.fullmatch(record["sourceCommit"]) is not None, "development ownership commit is invalid")
+    require(isinstance(record["productVersion"], str) and SAFE_VERSION.fullmatch(record["productVersion"]) is not None, "development ownership version is invalid")
+    require(SHA40.fullmatch(record["sourceTree"]) is not None, "development ownership source tree is invalid")
+    require(record["versionSource"] == "include/rp1_gpclk/version.h", "development ownership version source differs")
+    require(record["compatibilityIdentity"] == COMPATIBILITY_IDENTITY, "development ownership compatibility identity differs")
+    require(record["targetKernel"] == platform.release(), "development ownership targets a different running kernel")
+    for field in (
+        "uapiSha256", "versionSourceSha256", "rollbackRecordSha256",
+        "rollbackEntrypointSha256", "installedModuleSha256", "decompressedModuleSha256",
+    ):
+        require_hash(record[field], field)
+    evidence = pathlib.Path(record["upstreamEvidence"])
+    expected_parent = pathlib.Path("/var/lib/wsprrypi")
+    if root != pathlib.Path("/"):
+        expected_parent = root_path(root, str(expected_parent))
+    require(
+        evidence.parent == expected_parent
+        and re.fullmatch(r"rp1-gpclk-dkms-development-evidence\.[0-9a-f]{24}", evidence.name) is not None,
+        "development ownership evidence path differs",
+    )
+    rollback = secure_owned_path(pathlib.Path(record["rollbackRecord"]), evidence, "development rollback record")
+    entrypoint = secure_owned_path(pathlib.Path(record["rollbackEntrypoint"]), evidence, "development rollback entrypoint")
+    require(rollback == evidence / "ROLLBACK.json", "development rollback record path differs")
+    require(entrypoint == evidence / "rendered-source/scripts/development-rollback", "development rollback entrypoint path differs")
+    require(sha256_file(rollback) == record["rollbackRecordSha256"], "development rollback record identity differs")
+    require(sha256_file(entrypoint) == record["rollbackEntrypointSha256"], "development rollback entrypoint identity differs")
+    inventory = existing_inventory(root, runner)
+    require(inventory["packageVersion"] is None, "a Debian-owned RP1 provider blocks development rollback")
+    require(not inventory["activeModule"], "an active RP1 GPCLK module blocks owned provider removal")
+    require(not inventory["configuredRoute"], "a configured RP1 GPCLK route blocks owned provider removal")
+    require(not inventory["enrollment"] and not inventory["developmentManager"], "development enrollment or manager binding blocks owned provider removal")
+    version = record["productVersion"]
+    dkms_lines = [line for line in inventory["dkms"].splitlines() if line.strip()]
+    expected_dkms = re.compile(rf"^{re.escape(DKMS_NAME)}/{re.escape(version)}[^\n]*installed$")
+    require(bool(dkms_lines) and all(expected_dkms.fullmatch(line) for line in dkms_lines), "development DKMS registration differs from WsprryPi ownership")
+    expected_source = str(root_path(root, f"/usr/src/{PACKAGE_NAME}-{version}"))
+    require(inventory["sourceTrees"] == [expected_source], "development source destination differs from WsprryPi ownership")
+    require(not inventory["installedOverlays"], "installed RP1 route overlays block development rollback")
+    installed_path = pathlib.Path(record["installedModulePath"])
+    expected_prefix = pathlib.Path(f"/lib/modules/{record['targetKernel']}/updates/dkms")
+    require(installed_path.is_absolute() and installed_path.parent == expected_prefix, "development installed module path is out of scope")
+    actual_installed = root_path(root, str(installed_path))
+    require(inventory["moduleCandidates"] == [str(actual_installed)], "development module destination differs from WsprryPi ownership")
+    require(actual_installed.is_file() and not actual_installed.is_symlink(), "development installed module is missing or substituted")
+    require(sha256_file(actual_installed) == record["installedModuleSha256"], "development installed module identity differs")
+    return entrypoint, rollback
+
+
+def verify_provider_absent(root: pathlib.Path, runner: Runner) -> None:
+    inventory = existing_inventory(root, runner)
+    require(
+        inventory["packageVersion"] is None
+        and not inventory["dkms"]
+        and not inventory["activeModule"]
+        and not inventory["sourceTrees"]
+        and not inventory["moduleCandidates"]
+        and not inventory["installedOverlays"]
+        and not inventory["configuredRoute"]
+        and not inventory["enrollment"]
+        and not inventory["developmentManager"],
+        "provider removal completed with residual or active RP1 state",
+    )
+
+
+def remove_owned_provider(args: argparse.Namespace, runner: Runner) -> None:
+    if args.remove == "false":
+        print("RP1-GPCLK-DKMS preserved: explicit operator opt-out.")
+        return
+    record, identity, reason = load_ownership_record(args.record)
+    if record is None or identity is None:
+        print(f"RP1-GPCLK-DKMS preserved: {reason or 'WsprryPi ownership is unproven'}.")
+        return
+    try:
+        root = args.root.resolve(strict=True)
+    except OSError as error:
+        raise ContractError("provider inventory root is unavailable") from error
+    try:
+        if record["channel"] == "release":
+            validate_release_removal(record, root, runner)
+            command = ["apt-get", "remove", "-y", PACKAGE_NAME]
+            working_directory = None
+        else:
+            entrypoint, rollback = validate_development_removal(record, root, runner)
+            command = [str(entrypoint), "--record", str(rollback)]
+            working_directory = entrypoint.parents[1]
+    except ContractError as error:
+        print(f"RP1-GPCLK-DKMS preserved: installed state does not match WsprryPi ownership ({error}).")
+        return
+    current_record, current_identity, current_reason = load_ownership_record(args.record)
+    require(
+        current_record == record
+        and current_identity is not None
+        and (current_identity.st_dev, current_identity.st_ino) == (identity.st_dev, identity.st_ino),
+        f"installation ownership changed before provider removal: {current_reason or 'identity mismatch'}",
+    )
+    runner.run(command, cwd=working_directory, passthrough=True)
+    verify_provider_absent(root, runner)
+    remove_ownership_record(args.record, identity)
+    print("WsprryPi-owned RP1-GPCLK-DKMS provider removed and absence verified.")
 
 
 def load_plan(state_dir: pathlib.Path) -> dict[str, Any]:
@@ -1093,6 +1405,11 @@ def parser() -> argparse.ArgumentParser:
     apply_parser.add_argument("--record", type=pathlib.Path, default=pathlib.Path("/var/lib/wsprrypi/rp1-gpclk-dkms-installation.json"))
     apply_parser.add_argument("--root", type=pathlib.Path, default=pathlib.Path("/"))
     apply_parser.add_argument("--debug", action="store_true")
+    remove_parser = sub.add_parser("remove")
+    remove_parser.add_argument("--remove", choices=("auto", "true", "false"), default="auto")
+    remove_parser.add_argument("--record", type=pathlib.Path, default=pathlib.Path("/var/lib/wsprrypi/rp1-gpclk-dkms-installation.json"))
+    remove_parser.add_argument("--root", type=pathlib.Path, default=pathlib.Path("/"))
+    remove_parser.add_argument("--debug", action="store_true")
     return result
 
 
@@ -1101,10 +1418,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         if args.command == "prepare":
             prepare(args, Runner(args.debug))
-        else:
+        elif args.command == "apply":
             apply(args, Runner(args.debug))
+        else:
+            remove_owned_provider(args, Runner(args.debug))
     except ContractError as error:
-        print(f"RP1-GPCLK-DKMS installation refused: {error}", file=sys.stderr)
+        print(f"RP1-GPCLK-DKMS operation refused: {error}", file=sys.stderr)
         return 1
     return 0
 

--- a/scripts/tests/rp1_gpclk_dkms_install_test.py
+++ b/scripts/tests/rp1_gpclk_dkms_install_test.py
@@ -552,9 +552,7 @@ class ApplyPolicyTests(unittest.TestCase):
         with mock.patch.object(MOD, "validate_package"):
             MOD.apply_release(self.state, self.resolved, self.record, self.root, runner)
         self.assertFalse(any(call and call[0] == "apt-get" for call in runner.calls))
-        recorded = json.loads(self.record.read_text())
-        self.assertEqual(recorded["sourceCommit"], "a" * 40)
-        self.assertFalse(recorded["qualificationClaim"])
+        self.assertFalse(self.record.exists(), "pre-existing exact providers must not become WsprryPi-owned")
 
     def test_exact_installation_rejects_foreign_same_version_state(self):
         member = self.manifest["packageInventory"][0]
@@ -572,11 +570,21 @@ class ApplyPolicyTests(unittest.TestCase):
 
     def test_fresh_release_uses_normal_debian_path(self):
         runner = FakeRunner(self.responses())
-        with mock.patch.object(MOD, "validate_package"), mock.patch.object(MOD, "verify_installed_release"):
+        artifacts = [{
+            "path": "/lib/modules/fixture/updates/dkms/rp1_gpclk_dkms.ko",
+            "sha256": digest(b"module"),
+        }]
+        with mock.patch.object(MOD, "validate_package"), \
+             mock.patch.object(MOD, "verify_installed_release"), \
+             mock.patch.object(MOD, "module_artifacts", return_value=artifacts):
             MOD.apply_release(self.state, self.resolved, self.record, self.root, runner)
         apt_calls = [call for call in runner.calls if call and call[0] == "apt-get"]
         self.assertEqual(apt_calls, [("apt-get", "install", "--no-install-recommends", "-y", str(self.package))])
         self.assertEqual(runner.passthrough_calls, apt_calls)
+        recorded = json.loads(self.record.read_text())
+        self.assertEqual(recorded["schema"], MOD.RECORD_SCHEMA)
+        self.assertEqual(recorded["owner"], "WsprryPi")
+        self.assertEqual(recorded["moduleArtifacts"][0]["sha256"], digest(b"module"))
 
     def test_dry_run_plan_cannot_be_applied(self):
         model = self.root / "model"
@@ -700,12 +708,69 @@ cleanup_rp1_gpclk_dkms_state
         self.assertEqual(arguments.count("CALL"), 2)
         self.assertEqual(arguments.count("ARG=--debug"), 2)
 
-    def test_uninstall_and_forbidden_operations_absent_from_installer_paths(self):
+    def test_selected_uninstall_dry_run_displays_helper_without_invoking_python(self):
+        install_script = ROOT / "scripts" / "install.sh"
+        sentinel = self.root / "uninstall-python-invoked"
+        shell = r'''
+source "$INSTALL_SCRIPT"
+python3() { printf python3 >"$SENTINEL"; return 99; }
+curl() { printf curl >"$SENTINEL"; return 99; }
+mktemp() { printf mktemp >"$SENTINEL"; return 99; }
+DRY_RUN=true
+ACTION=uninstall
+REPO_ORG=WsprryPi
+REPO_NAME=WsprryPi
+REPO_BRANCH=devel
+FGGLD= RESET= FGGRN= FGRED= MOVE_UP= CLEAR_LINE=
+remove_owned_rp1_gpclk_dkms_provider debug
+[[ ! -e "$SENTINEL" ]]
+cleanup_rp1_gpclk_dkms_state
+'''
+        environment = os.environ.copy()
+        environment.update({"INSTALL_SCRIPT": str(install_script), "SENTINEL": str(sentinel)})
+        result = subprocess.run(
+            ["bash", "-c", shell], text=True, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, env=environment, check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(sentinel.exists())
+        self.assertEqual(result.stdout.count("(dry)"), 2)
+        helper = install_script.parent / "rp1_gpclk_dkms_install.py"
+        self.assertIn(
+            f"Command: python3 {helper} remove --remove auto --debug",
+            result.stderr,
+        )
+
+    def test_uninstall_opt_out_never_prepares_or_invokes_helper(self):
+        install_script = ROOT / "scripts" / "install.sh"
+        sentinel = self.root / "opt-out-helper-activity"
+        shell = r'''
+source "$INSTALL_SCRIPT"
+python3() { printf python3 >"$SENTINEL"; return 99; }
+curl() { printf curl >"$SENTINEL"; return 99; }
+mktemp() { printf mktemp >"$SENTINEL"; return 99; }
+logI() { :; }
+DRY_RUN=false
+ACTION=uninstall
+REMOVE_RP1_GPCLK_DKMS=false
+remove_owned_rp1_gpclk_dkms_provider debug
+[[ ! -e "$SENTINEL" ]]
+[[ -z "$RP1_GPCLK_DKMS_STATE_DIR" && -z "$RP1_GPCLK_DKMS_HELPER" ]]
+'''
+        environment = os.environ.copy()
+        environment.update({"INSTALL_SCRIPT": str(install_script), "SENTINEL": str(sentinel)})
+        result = subprocess.run(
+            ["bash", "-c", shell], text=True, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, env=environment, check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(sentinel.exists())
+
+    def test_forbidden_runtime_operations_absent_from_installer_paths(self):
         install_source = (ROOT / "scripts/install.sh").read_text()
         helper_source = SCRIPT.read_text()
         self.assertIn('[[ "$ACTION" == "install" ]] || return 0', install_source)
         self.assertNotRegex(helper_source, r'\["(?:dtoverlay|modprobe|insmod|rmmod|systemctl|service|reboot|shutdown)"')
-        self.assertNotIn("apt-get remove", helper_source)
         self.assertNotRegex(helper_source, r"config\.txt[^\n]*(?:write|replace|unlink)")
 
     def test_prepare_precedes_package_mutation_and_apply_follows_dependencies(self):
@@ -736,13 +801,193 @@ cleanup_rp1_gpclk_dkms_state
             self.assertIn("explicitly requested", body)
         self.assertIn('"$file" == "/proc/device-tree/compatible"', function_body("validate_sys_accs"))
 
-    def test_temporary_cleanup_is_scoped_and_uninstall_preserves_provider(self):
+    def test_temporary_cleanup_is_scoped_and_uninstall_uses_owned_provider_step(self):
         source = (ROOT / "scripts/install.sh").read_text()
         cleanup_start = source.index("cleanup_rp1_gpclk_dkms_state() {")
         cleanup = source[cleanup_start:source.index("\n}\n", cleanup_start) + 3]
         self.assertIn("/tmp/wsprrypi-rp1-gpclk-dkms.*", cleanup)
         self.assertIn("Refusing to remove unexpected", cleanup)
-        self.assertIn('[[ "$ACTION" == "install" ]] || return 0', source)
+        self.assertIn('group_to_execute+=("remove_owned_rp1_gpclk_dkms_provider")', source)
+
+
+class RemovalPolicyTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = pathlib.Path(self.temp.name).resolve()
+        self.record = self.root / "ownership.json"
+
+    def release_record(self) -> dict[str, object]:
+        return {
+            "schema": MOD.RECORD_SCHEMA, "repository": MOD.REPOSITORY,
+            "owner": "WsprryPi", "channel": "release",
+            "installationMethod": "debian-package", "tag": "v2.1.0",
+            "sourceCommit": "a" * 40, "manifest": valid_manifest(),
+            "moduleArtifacts": [{
+                "path": "/lib/modules/fixture/updates/dkms/rp1_gpclk_dkms.ko",
+                "sha256": "c" * 64,
+            }],
+            "routeActivation": "disabled", "output": "disabled",
+            "qualificationClaim": False,
+        }
+
+    def development_record(self) -> dict[str, object]:
+        return {
+            "schema": MOD.RECORD_SCHEMA, "repository": MOD.REPOSITORY,
+            "owner": "WsprryPi", "channel": "development",
+            "installationMethod": "upstream-development-rollback",
+            "sourceCommit": "a" * 40, "productVersion": "0.9.0",
+            "sourceTree": "b" * 40, "uapiSha256": "c" * 64,
+            "versionSource": "include/rp1_gpclk/version.h",
+            "versionSourceSha256": "d" * 64,
+            "targetKernel": MOD.platform.release(),
+            "compatibilityIdentity": MOD.COMPATIBILITY_IDENTITY,
+            "upstreamEvidence": "/var/lib/wsprrypi/rp1-gpclk-dkms-development-evidence",
+            "rollbackRecord": "/var/lib/wsprrypi/rp1-gpclk-dkms-development-evidence/ROLLBACK.json",
+            "rollbackRecordSha256": "e" * 64,
+            "rollbackEntrypoint": "/var/lib/wsprrypi/rp1-gpclk-dkms-development-evidence/rendered-source/scripts/development-rollback",
+            "rollbackEntrypointSha256": "f" * 64,
+            "installedModulePath": f"/lib/modules/{MOD.platform.release()}/updates/dkms/rp1_gpclk_dkms.ko",
+            "installedModuleSha256": "1" * 64,
+            "decompressedModuleSha256": "2" * 64,
+            "routeActivation": "disabled", "output": "disabled",
+            "qualificationClaim": False,
+        }
+
+    def write_record(self, value: dict[str, object]) -> None:
+        self.record.write_text(json.dumps(value))
+        self.record.chmod(0o600)
+
+    def args(self):
+        return MOD.parser().parse_args(["remove", "--record", str(self.record), "--root", str(self.root)])
+
+    def test_missing_legacy_malformed_and_symlink_records_preserve_provider(self):
+        runner = FakeRunner()
+        stdout = io.StringIO()
+        with mock.patch.object(MOD.sys, "stdout", stdout):
+            MOD.remove_owned_provider(self.args(), runner)
+        self.assertIn("preserved", stdout.getvalue())
+        self.assertEqual(runner.calls, [])
+
+        for value in (
+            {"schema": MOD.LEGACY_RECORD_SCHEMA},
+            {"schema": MOD.RECORD_SCHEMA, "owner": "attacker"},
+            {**self.release_record(), "tag": 210},
+        ):
+            self.write_record(value)
+            stdout = io.StringIO()
+            with mock.patch.object(MOD.sys, "stdout", stdout):
+                MOD.remove_owned_provider(self.args(), runner)
+            self.assertIn("preserved", stdout.getvalue())
+            self.assertTrue(self.record.exists())
+            self.record.unlink()
+
+        target = self.root / "target.json"
+        target.write_text(json.dumps(self.release_record()))
+        self.record.symlink_to(target)
+        stdout = io.StringIO()
+        with mock.patch.object(MOD.sys, "stdout", stdout):
+            MOD.remove_owned_provider(self.args(), runner)
+        self.assertIn("preserved", stdout.getvalue())
+        self.assertTrue(target.exists())
+
+    def test_explicit_opt_out_preserves_even_a_valid_owned_provider(self):
+        self.write_record(self.release_record())
+        args = MOD.parser().parse_args([
+            "remove", "--remove", "false", "--record", str(self.record),
+            "--root", str(self.root),
+        ])
+        runner = FakeRunner()
+        stdout = io.StringIO()
+        with mock.patch.object(MOD.sys, "stdout", stdout):
+            MOD.remove_owned_provider(args, runner)
+        self.assertIn("explicit operator opt-out", stdout.getvalue())
+        self.assertTrue(self.record.exists())
+        self.assertEqual(runner.calls, [])
+
+    def test_owned_release_uses_package_removal_then_deletes_record(self):
+        self.write_record(self.release_record())
+        runner = FakeRunner()
+        with mock.patch.object(MOD, "validate_release_removal"), \
+             mock.patch.object(MOD, "verify_provider_absent"):
+            MOD.remove_owned_provider(self.args(), runner)
+        self.assertEqual(runner.passthrough_calls, [("apt-get", "remove", "-y", MOD.PACKAGE_NAME)])
+        self.assertFalse(self.record.exists())
+
+    def test_identity_drift_preserves_record_without_package_mutation(self):
+        self.write_record(self.release_record())
+        runner = FakeRunner()
+        stdout = io.StringIO()
+        with mock.patch.object(MOD, "validate_release_removal", side_effect=MOD.ContractError("artifact drift")), \
+             mock.patch.object(MOD.sys, "stdout", stdout):
+            MOD.remove_owned_provider(self.args(), runner)
+        self.assertIn("artifact drift", stdout.getvalue())
+        self.assertEqual(runner.calls, [])
+        self.assertTrue(self.record.exists())
+
+    def test_release_allows_only_same_version_additional_kernel_artifacts(self):
+        record = self.release_record()
+        artifacts = [
+            *record["moduleArtifacts"],
+            {
+                "path": "/lib/modules/new-kernel/updates/dkms/rp1_gpclk_dkms.ko.xz",
+                "sha256": "d" * 64,
+            },
+        ]
+        responses = {
+            ("modinfo", "-k", "fixture", "-F", "version", MOD.MODULE_NAME): MOD.CommandResult("2.1.0\n", "", 0),
+            ("modinfo", "-k", "new-kernel", "-F", "version", MOD.MODULE_NAME): MOD.CommandResult("2.1.0\n", "", 0),
+        }
+        runner = FakeRunner(responses)
+        with mock.patch.object(MOD, "verify_installed_release"), \
+             mock.patch.object(MOD, "module_artifacts", return_value=artifacts):
+            MOD.validate_release_removal(record, self.root, runner)
+        runner.responses[("modinfo", "-k", "new-kernel", "-F", "version", MOD.MODULE_NAME)] = MOD.CommandResult("9.9.9\n", "", 0)
+        with mock.patch.object(MOD, "verify_installed_release"), \
+             mock.patch.object(MOD, "module_artifacts", return_value=artifacts):
+            with self.assertRaisesRegex(MOD.ContractError, "additional-kernel"):
+                MOD.validate_release_removal(record, self.root, runner)
+
+    def test_package_removal_failure_retains_record_and_fails(self):
+        self.write_record(self.release_record())
+        failed = MOD.CommandResult("", "package busy", 1)
+        runner = FakeRunner({("apt-get", "remove", "-y", MOD.PACKAGE_NAME): failed})
+        with mock.patch.object(MOD, "validate_release_removal"):
+            with self.assertRaises(MOD.ContractError):
+                MOD.remove_owned_provider(self.args(), runner)
+        self.assertTrue(self.record.exists())
+
+    def test_record_change_after_preflight_blocks_package_mutation(self):
+        self.write_record(self.release_record())
+        runner = FakeRunner()
+
+        def change_record(*_):
+            changed = self.release_record()
+            changed["sourceCommit"] = "b" * 40
+            self.write_record(changed)
+
+        with mock.patch.object(MOD, "validate_release_removal", side_effect=change_record):
+            with self.assertRaisesRegex(MOD.ContractError, "ownership changed"):
+                MOD.remove_owned_provider(self.args(), runner)
+        self.assertEqual(runner.calls, [])
+        self.assertTrue(self.record.exists())
+
+    def test_owned_development_uses_captured_upstream_rollback(self):
+        self.write_record(self.development_record())
+        evidence = self.root / "evidence/rendered-source/scripts"
+        evidence.mkdir(parents=True)
+        entrypoint = evidence / "development-rollback"
+        entrypoint.write_text("#!/bin/sh\n")
+        entrypoint.chmod(0o700)
+        rollback = self.root / "evidence/ROLLBACK.json"
+        rollback.write_text("{}")
+        rollback.chmod(0o600)
+        runner = FakeRunner()
+        with mock.patch.object(MOD, "validate_development_removal", return_value=(entrypoint, rollback)), \
+             mock.patch.object(MOD, "verify_provider_absent"):
+            MOD.remove_owned_provider(self.args(), runner)
+        self.assertEqual(runner.passthrough_calls, [(str(entrypoint), "--record", str(rollback))])
+        self.assertFalse(self.record.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- record v2 ownership only for provider installations actually performed by WsprryPi
- remove unchanged owned release or development providers through canonical upstream lifecycle paths
- preserve pre-existing, legacy, ambiguous, drifted, active, or explicitly retained providers
- keep uninstall dry-run/debug behavior mutation-free and explicit

## Validation
- 50 RP1 installer lifecycle tests
- installer dependency suite including 14 dry-run purity tests
- ShellCheck, Bash syntax, Python compilation, and whitespace checks
- repeated adversarial review and repair