### PR TITLE
Gate RP1 removal on successful teardown

### DIFF
--- a/docs/rp1-gpclk-dkms-installation.md
+++ b/docs/rp1-gpclk-dkms-installation.md
@@ -139,6 +139,11 @@ and rollback record captured during installation. WsprryPi never invents a
 direct DKMS, module unload, overlay, route, boot, service, GPIO, or RF removal
 sequence.
 
+If any preceding WsprryPi uninstall step fails, safe teardown continues where
+possible, but provider removal is skipped. The provider and ownership record
+are preserved, the overall uninstall fails, and no uninstall-success message is
+reported.
+
 The ownership record is deleted only after the canonical removal succeeds and
 the helper verifies that package, DKMS, source, module, overlay, route,
 enrollment, and manager state are absent. A lifecycle failure retains the

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8442,6 +8442,18 @@ manage_wsprry_pi() {
     for func in "${group_to_execute[@]}"; do
         local function_name="${func%% *}" # Extract only function name
 
+        # Provider removal is ownership-sensitive and may run only after every
+        # preceding uninstall step has completed successfully. Continue safe
+        # teardown after failures, but preserve the provider and its ownership
+        # record when the WsprryPi teardown is incomplete.
+        if [[ "$ACTION" == "uninstall" && \
+            "$function_name" == "remove_owned_rp1_gpclk_dkms_provider" && \
+            "$overall_status" -ne 0 ]]; then
+            warn "Skipping RP1-GPCLK-DKMS provider removal because earlier WsprryPi uninstall steps failed; the provider and ownership record were preserved."
+            debug_print "$func skipped after incomplete WsprryPi teardown." "$debug"
+            continue
+        fi
+
         # Execute the function
         debug_print "Running $func() with action: '$ACTION'" "$debug"
         # Disable -e (crash out on error) temporarily
@@ -8458,9 +8470,9 @@ manage_wsprry_pi() {
                 restore_daemon_state "${func}" "${debug}"
                 overall_status=1
                 break
-            elif [[ "$function_name" == "remove_owned_rp1_gpclk_dkms_provider" ]]; then
-                # Do not report uninstall success after a partially completed
-                # provider lifecycle. Its ownership record remains for recovery.
+            elif [[ "$ACTION" == "uninstall" ]]; then
+                # Continue safe teardown, but retain every failure so provider
+                # removal is gated and uninstall success cannot be reported.
                 overall_status=1
             fi
         else

--- a/scripts/tests/rp1_gpclk_dkms_install_test.py
+++ b/scripts/tests/rp1_gpclk_dkms_install_test.py
@@ -809,6 +809,89 @@ remove_owned_rp1_gpclk_dkms_provider debug
         self.assertIn("Refusing to remove unexpected", cleanup)
         self.assertIn('group_to_execute+=("remove_owned_rp1_gpclk_dkms_provider")', source)
 
+    def run_uninstall_orchestration(self, failing_step=""):
+        install_script = ROOT / "scripts" / "install.sh"
+        capture = self.root / f"uninstall-{failing_step or 'success'}.txt"
+        shell = r'''
+source "$INSTALL_SCRIPT"
+ACTION=uninstall
+DRY_RUN=false
+NO_WEB=false
+
+record_step() {
+    printf '%s\n' "$1" >>"$CAPTURE"
+    [[ "$1" != "$FAILING_STEP" ]]
+}
+manage_apache() { record_step manage_apache; }
+manage_web() { record_step manage_web; }
+manage_service() { record_step manage_service; }
+manage_i2c() { record_step manage_i2c; }
+manage_config() { record_step manage_config; }
+manage_route_application() { record_step manage_route_application; }
+manage_support_bundle_runtime() { record_step manage_support_bundle_runtime; }
+manage_exe() { record_step manage_exe; }
+manage_sound() { record_step manage_sound; }
+remove_owned_rp1_gpclk_dkms_provider() { record_step remove_owned_rp1_gpclk_dkms_provider; }
+flag_need_reboot() { record_step flag_need_reboot; }
+eval "$(declare -f finish_script | sed '1s/finish_script/original_finish_script/')"
+finish_script() {
+    printf 'finish_status=%s\n' "$1" >>"$CAPTURE"
+    original_finish_script "$@"
+}
+logE() { :; }
+warn() { printf 'warning=%s\n' "$*" >>"$CAPTURE"; }
+
+status=0
+manage_wsprry_pi || status=$?
+printf 'return_status=%s\n' "$status" >>"$CAPTURE"
+'''
+        environment = os.environ.copy()
+        environment.update({
+            "INSTALL_SCRIPT": str(install_script),
+            "CAPTURE": str(capture),
+            "FAILING_STEP": failing_step,
+        })
+        result = subprocess.run(
+            ["bash", "-c", shell], text=True, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, env=environment, check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return capture.read_text().splitlines(), result.stdout
+
+    def test_teardown_failures_skip_owned_provider_removal_and_fail_uninstall(self):
+        expected_teardown = {
+            "manage_apache", "manage_web", "manage_service", "manage_i2c",
+            "manage_config", "manage_route_application",
+            "manage_support_bundle_runtime", "manage_exe", "manage_sound",
+            "flag_need_reboot",
+        }
+        for failing_step in ("manage_service", "manage_route_application", "manage_exe"):
+            with self.subTest(failing_step=failing_step):
+                lines, stdout = self.run_uninstall_orchestration(failing_step)
+                self.assertTrue(expected_teardown.issubset(lines))
+                self.assertNotIn("remove_owned_rp1_gpclk_dkms_provider", lines)
+                self.assertIn("finish_status=1", lines)
+                self.assertIn("return_status=1", lines)
+                self.assertTrue(any("provider and ownership record were preserved" in line for line in lines))
+                self.assertNotIn("Uninstallation successful", stdout)
+                self.assertNotIn("has been uninstalled", stdout)
+
+    def test_successful_teardown_runs_owned_provider_removal_last(self):
+        lines, stdout = self.run_uninstall_orchestration()
+        provider = lines.index("remove_owned_rp1_gpclk_dkms_provider")
+        self.assertGreater(provider, lines.index("manage_sound"))
+        self.assertIn("finish_status=0", lines)
+        self.assertIn("return_status=0", lines)
+        self.assertIn("Uninstallation successful", stdout)
+
+    def test_owned_provider_removal_failure_fails_uninstall(self):
+        lines, stdout = self.run_uninstall_orchestration("remove_owned_rp1_gpclk_dkms_provider")
+        self.assertIn("remove_owned_rp1_gpclk_dkms_provider", lines)
+        self.assertIn("finish_status=1", lines)
+        self.assertIn("return_status=1", lines)
+        self.assertNotIn("Uninstallation successful", stdout)
+        self.assertNotIn("has been uninstalled", stdout)
+
 
 class RemovalPolicyTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- retain every uninstall-step failure while continuing safe teardown
- skip ownership-aware RP1 provider removal after incomplete teardown
- verify failure, success, and provider-removal paths with injected shell regressions
- document provider preservation after teardown failure

## Validation
- make -C src rp1-gpclk-dkms-installer-test installer-dependency-test SUDO=
- python3 scripts/tests/installer_dry_run_purity_test.py
- bash -n scripts/install.sh
- shellcheck --severity=warning scripts/install.sh
- git diff --check