### PR TITLE
Correct installer dry-run status classification

### DIFF
--- a/docs/rp1-gpclk-dkms-installation.md
+++ b/docs/rp1-gpclk-dkms-installation.md
@@ -98,13 +98,14 @@ Before package mutation a real installation displays the WsprryPi channel,
 detected platform, selection reason and override state, requested and resolved
 source, immutable tag or commit, version and expected hashes, lifecycle command
 class, and the output-disabled boundary. With `DRY_RUN=true`, the standard
-installer command wrapper reports both RP1 planning and application commands
-as skipped and does not invoke Python, download or clone provider inputs, run
-upstream preflight, inspect a package, or mutate provider state. Debug mode
-shows the exact helper command; during a real run it also reports the helper's
-external command argv and captured validation output. The resolved plan and
-ordinary package/DKMS or upstream lifecycle output remain visible during a real
-installation even when debug mode is off.
+installer command wrapper reports RP1 plan resolution as informational context
+and the application command as a skipped execution item. It does not invoke
+Python, download or clone provider inputs, run upstream preflight, inspect a
+package, or mutate provider state. Debug mode shows the exact helper command;
+during a real run it also reports the helper's external command argv and
+captured validation output. The resolved plan and ordinary package/DKMS or
+upstream lifecycle output remain visible during a real installation even when
+debug mode is off.
 
 Only when WsprryPi actually mutates an empty provider state and then verifies
 the result does it atomically create the root-owned, mode-0600 v2 ownership

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1924,6 +1924,7 @@ exec_command() {
     local status=0 exec_name running_pre complete_pre failed_pre
     local args cmd cmd_str
     local show_output="${EXEC_COMMAND_SHOW_OUTPUT:-false}"
+    local status_mode="${EXEC_COMMAND_STATUS_MODE:-execution}"
 
     # Assign the human readable name and shift it off
     exec_name="$1"; shift
@@ -1945,6 +1946,42 @@ exec_command() {
     if [[ "$debug" == "debug" ]]; then
         debug_print "Name:    $exec_name" "$debug"
         debug_print "Command: $cmd_str" "$debug"
+    fi
+
+    case "$status_mode" in
+        execution|info) ;;
+        *)
+            warn "Unsupported exec_command status mode: $status_mode"
+            debug_end "$debug"
+            return 2
+            ;;
+    esac
+
+    # Read-only planning is useful operator context, not a completed mutation.
+    # Keep it inside this wrapper so dry runs still suppress command execution
+    # and debug mode still renders the exact argv.
+    if [[ "$status_mode" == "info" ]]; then
+        logI "$exec_name."
+        if [[ "$DRY_RUN" == "true" ]]; then
+            debug_end "$debug"
+            return 0
+        fi
+
+        if [[ "$debug" == "debug" || "$show_output" == "true" ]]; then
+            "${cmd[@]}" || status=$?
+        else
+            "${cmd[@]}" &>/dev/null || status=$?
+        fi
+        if [[ $status -ne 0 ]]; then
+            logE "Failed: $exec_name."
+            if [[ $status -eq 127 ]]; then
+                warn "Command not found: ${cmd_str}"
+            else
+                warn "Command failed with status $status: ${cmd_str}"
+            fi
+        fi
+        debug_end "$debug"
+        return "$status"
     fi
 
     # Prepare status prefixes
@@ -2332,7 +2369,8 @@ prepare_rp1_gpclk_dkms_installation() {
         prepare_args+=(--debug)
     fi
 
-    if ! EXEC_COMMAND_SHOW_OUTPUT=true exec_command "Resolve RP1-GPCLK-DKMS installation plan" \
+    if ! EXEC_COMMAND_SHOW_OUTPUT=true EXEC_COMMAND_STATUS_MODE=info \
+        exec_command "Resolve RP1-GPCLK-DKMS installation plan" \
         python3 "$RP1_GPCLK_DKMS_HELPER" "${prepare_args[@]}" "$debug"; then
         warn "RP1-GPCLK-DKMS installation planning failed before package mutation."
         cleanup_rp1_gpclk_dkms_state
@@ -5245,26 +5283,30 @@ handle_apt_packages() {
 }
 
 # shellcheck disable=SC2317
+run_support_bundle_age_dependency_validation() {
+    # shellcheck source=scripts/support_bundle_age_dependency.sh
+    source "${LOCAL_REPO_DIR}/scripts/support_bundle_age_dependency.sh" &&
+        support_bundle_validate_age_dependency
+}
+
+# shellcheck disable=SC2317
 validate_support_bundle_age_dependency() {
     local debug
     debug=$(debug_start "$@")
     eval set -- "$(debug_filter "$@")"
 
-    if [[ "$DRY_RUN" == "true" ]]; then
-        logI "Dry run: would validate the support-bundle encryption tools."
-        debug_end "$debug"
-        return 0
-    fi
-
-    # shellcheck source=scripts/support_bundle_age_dependency.sh
-    if ! source "${LOCAL_REPO_DIR}/scripts/support_bundle_age_dependency.sh" ||
-        ! support_bundle_validate_age_dependency; then
+    if ! exec_command "Validate support-bundle encryption tools" \
+        run_support_bundle_age_dependency_validation "$debug"; then
         logE "Required support-bundle encryption tools are unavailable or unsafe."
         debug_print "Support-bundle encryption validation status: ${SUPPORT_BUNDLE_AGE_DEPENDENCY_ERROR:-helper_unavailable}." "$debug"
         debug_end "$debug"
         return 1
     fi
-    debug_print "Validated fixed support-bundle encryption tools." "$debug"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        debug_print "Support-bundle encryption validation planned but not executed." "$debug"
+    else
+        debug_print "Validated fixed support-bundle encryption tools." "$debug"
+    fi
     debug_end "$debug"
     return 0
 }

--- a/scripts/tests/installer_dependency_test.sh
+++ b/scripts/tests/installer_dependency_test.sh
@@ -66,8 +66,13 @@ if ! awk '
     exit 1
 fi
 
-if ! grep -Fq 'Dry run: would validate the support-bundle encryption tools.' "$INSTALLER"; then
-    echo "installer dry-run must report age validation without executing it" >&2
+if ! grep -Fq 'exec_command "Validate support-bundle encryption tools"' "$INSTALLER"; then
+    echo "installer must route age validation through exec_command" >&2
+    exit 1
+fi
+
+if grep -Fq 'Dry run: would validate the support-bundle encryption tools.' "$INSTALLER"; then
+    echo "installer must not bypass the standard dry-run execution pathway for age validation" >&2
     exit 1
 fi
 

--- a/scripts/tests/installer_dry_run_purity_test.py
+++ b/scripts/tests/installer_dry_run_purity_test.py
@@ -184,6 +184,95 @@ exec_command "argv display" probe plain "two words" '$(not-executed)' 'semi;colo
         self.assertIn(expected, result.stderr)
         self.assertFalse(sentinel.exists())
 
+    def test_exec_command_info_mode_is_informational_and_suppresses_dry_run(self) -> None:
+        sentinel = self.root / "planning-command-invoked"
+        result = self.run_shell(
+            r'''
+source "$INSTALLER"
+probe() { printf invoked >"$SENTINEL"; return 99; }
+logI() { printf '[INFO ] %s\n' "$1"; }
+DRY_RUN=true
+FGGLD= RESET= FGGRN= FGRED= MOVE_UP= CLEAR_LINE=
+EXEC_COMMAND_STATUS_MODE=info exec_command "Resolve read-only plan" probe --exact argv debug
+[[ ! -e "$SENTINEL" ]]
+''',
+            SENTINEL=sentinel,
+        )
+        self.assertIn("[INFO ] Resolve read-only plan.", result.stdout)
+        self.assertNotIn("Running:", result.stdout)
+        self.assertNotIn("Complete:", result.stdout)
+        self.assertIn("Command: probe --exact argv", result.stderr)
+        self.assertFalse(sentinel.exists())
+
+    def test_exec_command_info_mode_propagates_live_failure(self) -> None:
+        result = self.run_shell(
+            r'''
+source "$INSTALLER"
+probe() { return 17; }
+logI() { printf '[INFO ] %s\n' "$1"; }
+logE() { printf '[ERROR] %s\n' "$1"; }
+DRY_RUN=false
+if EXEC_COMMAND_STATUS_MODE=info exec_command "Resolve read-only plan" probe; then
+    exit 1
+fi
+'''
+        )
+        self.assertIn("[INFO ] Resolve read-only plan.", result.stdout)
+        self.assertIn("[ERROR] Failed: Resolve read-only plan.", result.stdout)
+        self.assertIn("Command failed with status 17: probe", result.stderr)
+
+    def test_support_bundle_validation_uses_standard_dry_run_execution_item(self) -> None:
+        sentinel = self.root / "age-validation-invoked"
+        result = self.run_shell(
+            r'''
+source "$INSTALLER"
+run_support_bundle_age_dependency_validation() {
+    printf invoked >"$SENTINEL"
+    return 99
+}
+DRY_RUN=true
+FGGLD= RESET= FGGRN= FGRED= MOVE_UP= CLEAR_LINE=
+validate_support_bundle_age_dependency debug
+[[ ! -e "$SENTINEL" ]]
+''',
+            SENTINEL=sentinel,
+        )
+        self.assertIn(
+            "Complete: (dry) Validate support-bundle encryption tools.",
+            result.stdout,
+        )
+        self.assertNotIn(
+            "Dry run: would validate the support-bundle encryption tools.",
+            result.stdout,
+        )
+        self.assertIn(
+            "Command: run_support_bundle_age_dependency_validation",
+            result.stderr,
+        )
+        self.assertFalse(sentinel.exists())
+
+    def test_support_bundle_validation_propagates_live_execution_failure(self) -> None:
+        result = self.run_shell(
+            r'''
+source "$INSTALLER"
+run_support_bundle_age_dependency_validation() { return 23; }
+logE() { printf '[ERROR] %s\n' "$1" >&2; }
+DRY_RUN=false
+FGGLD= RESET= FGGRN= FGRED= MOVE_UP= CLEAR_LINE=
+if validate_support_bundle_age_dependency debug; then
+    exit 1
+fi
+'''
+        )
+        self.assertIn(
+            "Failed: Validate support-bundle encryption tools.",
+            result.stdout,
+        )
+        self.assertIn(
+            "Required support-bundle encryption tools are unavailable or unsafe.",
+            result.stderr,
+        )
+
     def test_placeholder_replacement_allows_planned_new_target(self) -> None:
         target = self.root / "not-installed-yet.ini"
         before = snapshot(self.root)

--- a/scripts/tests/rp1_gpclk_dkms_install_test.py
+++ b/scripts/tests/rp1_gpclk_dkms_install_test.py
@@ -607,6 +607,7 @@ class ApplyPolicyTests(unittest.TestCase):
         shell = r'''
 source "$INSTALL_SCRIPT"
 python3() { printf python3 >"$SENTINEL"; return 99; }
+logI() { printf '[INFO ] %s\n' "$1"; }
 curl() { printf curl >"$SENTINEL"; return 99; }
 mktemp() { printf mktemp >"$SENTINEL"; return 99; }
 git() { printf git >"$SENTINEL"; return 99; }
@@ -639,7 +640,19 @@ cleanup_rp1_gpclk_dkms_state
             )
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertFalse(sentinel.exists())
-            self.assertEqual(result.stdout.count("(dry)"), 4)
+            self.assertEqual(result.stdout.count("(dry)"), 2)
+            self.assertIn(
+                "[INFO ] Resolve RP1-GPCLK-DKMS installation plan.",
+                result.stdout,
+            )
+            self.assertNotIn(
+                "Complete: (dry) Resolve RP1-GPCLK-DKMS installation plan",
+                result.stdout,
+            )
+            self.assertIn(
+                "Complete: (dry) Apply RP1-GPCLK-DKMS installation plan",
+                result.stdout,
+            )
             self.assertIn("Name:    Resolve RP1-GPCLK-DKMS installation plan", result.stderr)
             self.assertIn("Name:    Apply RP1-GPCLK-DKMS installation plan", result.stderr)
             helper = install_script.parent / "rp1_gpclk_dkms_install.py"
@@ -684,6 +697,7 @@ python3() {
         printf 'ARG=%s\n' "$@"
     } >>"$CAPTURE"
 }
+logI() { printf '[INFO ] %s\n' "$1"; }
 logD() { :; }
 DRY_RUN=false
 ACTION=install
@@ -784,6 +798,7 @@ remove_owned_rp1_gpclk_dkms_provider debug
         self.assertNotRegex(source, r'if ! python3 "\$RP1_GPCLK_DKMS_HELPER"')
         self.assertEqual(source.count('exec_command "Resolve RP1-GPCLK-DKMS installation plan"'), 1)
         self.assertEqual(source.count('exec_command "Apply RP1-GPCLK-DKMS installation plan"'), 1)
+        self.assertIn('EXEC_COMMAND_STATUS_MODE=info', source)
         self.assertGreaterEqual(source.count('args+=(--debug)'), 2)
 
     def test_explicit_true_reaches_planner_without_raspberry_pi_identity(self):


### PR DESCRIPTION
## Summary
- classify RP1-GPCLK-DKMS plan resolution as informational output
- route support-bundle encryption validation through the standard dry-run execution wrapper
- add dry-run, debug argv, and live failure-propagation regressions
- update the maintained RP1 installer contract documentation

## Validation
- bash syntax and ShellCheck
- installer dry-run purity tests: 18 passed
- RP1-GPCLK-DKMS installer tests: 53 passed
- installer dependency and support-bundle age dependency tests passed
- adversarial review repeated after closing the live-failure coverage gap

No installation, service, module, GPIO, hardware, or RF operation was performed.