### PR TITLE
Restore selected RP1 routes idle through normal reboot startup

### DIFF
--- a/docs/rp1-gpclk-dkms-installation.md
+++ b/docs/rp1-gpclk-dkms-installation.md
@@ -7,6 +7,25 @@ lifecycle, select a GPIO route during installation, edit boot configuration, or
 enable output. A source or release that implements the reviewed runtime contract
 is activated only to route-neutral controller and manager administration.
 
+## Startup integration
+
+The selected application checkout installs `runtime_reconcile.py`, its
+application-owned installer support, `wsprrypi-rp1-reconcile.service`, and the
+`92-rp1-reconcile.conf` application drop-in through
+`scripts/install_runtime_reconcile.py install`. The normal installer and
+`scripts/copy_exe.py` invoke that helper. It records a fixed file inventory under
+`/var/lib/wsprrypi/rp1-startup-files.json`, preserves foreign files, and permits
+exact interrupted-installation retries. `remove` removes only that recorded
+inventory; neither operation starts a service or selects a route.
+
+Normal reboot recovery requires a provider supporting version-3 post-reboot
+activation plans and an application binary with the separate reboot-idle flag.
+A provider-only update does not supply this orchestration. See the
+[runtime workflow](runtime-route-workflow.md) for route and idle policy. Provider
+updates and rollback still use exact source/bundle provenance and the existing
+installation workflow; historical session values in installation provenance do
+not assert current-boot ownership.
+
 ## Selection
 
 `INSTALL_RP1_GPCLK_DKMS` accepts exactly:

--- a/docs/runtime-route-workflow.md
+++ b/docs/runtime-route-workflow.md
@@ -41,7 +41,9 @@ select a route. Ambiguous history, changed identities, a changed saved route,
 an intentionally stopped application, or an administrator mask fails closed.
 
 The startup pre-hook reads attributable history without querying the manager
-socket. `WSPRRYPI_RP1_REBOOT_IDLE` keeps bootstrap startup idle and skips an
+socket. If provider state is temporarily absent during installation or is
+unproven, the application can still start idle for diagnostics; the worker
+refuses administration until ownership is established. `WSPRRYPI_RP1_REBOOT_IDLE` keeps bootstrap startup idle and skips an
 obsolete route-readiness acknowledgement. It is distinct from the manager's
 fresh restoration token. Once the new route is restored, normal startup must
 acknowledge that exact token. Both flags keep transmission disabled without

--- a/docs/runtime-route-workflow.md
+++ b/docs/runtime-route-workflow.md
@@ -32,6 +32,25 @@ in idle mode; a previously stopped or administrator-masked application stays
 stopped. Saved `Enable on Boot` preferences and unrelated configuration remain
 unchanged. A stopped application's first subsequent startup is also idle.
 
+On a clean reboot, the application-owned `wsprrypi-rp1-reconcile.service`
+obtains fresh public provider activation and route plans. It runs outside the
+application service because neutral activation and route restoration stop and
+restart WsprryPi. A complete terminal prior-boot selection must match the saved
+GPIO4 or GPIO20 route. Neutral state or completed removal does not implicitly
+select a route. Ambiguous history, changed identities, a changed saved route,
+an intentionally stopped application, or an administrator mask fails closed.
+
+The startup pre-hook reads attributable history without querying the manager
+socket. `WSPRRYPI_RP1_REBOOT_IDLE` keeps bootstrap startup idle and skips an
+obsolete route-readiness acknowledgement. It is distinct from the manager's
+fresh restoration token. Once the new route is restored, normal startup must
+acknowledge that exact token. Both flags keep transmission disabled without
+changing the saved boot preference. A checkpoint under
+`/var/lib/wsprrypi/rp1-runtime-reconcile.json` binds the current boot, provider
+binding, activation-plan digest and saved route across worker interruption.
+Unsupported or interrupted provider hardware transitions retain their evidence
+for the provider's explicit recovery path.
+
 The browser may disconnect when its application stops. The Setup route-status
 dialog remains open, treats this interruption as expected, and retries read-only
 status queries with bounded backoff after the application restarts. It never
@@ -52,7 +71,8 @@ authorization.
 `runtime_route_client.py restore --execute` retries incomplete application
 restoration on the installed route without repeating overlay removal/application.
 An interrupted route change requires `recover --execute`, followed by a new
-explicit switch. Prior-boot state is never used to restart automatically.
+explicit switch. Prior-boot ownership and transmission intent are never reused.
+Normal clean-reboot reconciliation uses the separately described startup worker.
 Transmission is not resumed by either switching or restoration. The normal
 operator controls and application-owned RP1 operation authorization remain
 available; the kernel endpoint does not receive an authorization credential.
@@ -83,7 +103,7 @@ manual deployment must be reviewed during installation; it is not automatically
 removed or assumed to belong to this workflow.
 
 The startup-only `WSPRRYPI_ROUTE_RESTORE_IDLE` environment value is supplied by
-the manager's owned drop-in. It is not a transmission permit or operator setting.
+the manager's owned drop-in for a current route transaction. It is not a transmission permit or operator setting.
 Startup forces `Transmit=false` while preserving the stored boot preference;
 the token binds the application's readiness acknowledgement to this transaction.
 

--- a/scripts/copy_exe.py
+++ b/scripts/copy_exe.py
@@ -103,6 +103,7 @@ def main():
         run(["sudo", "install", "-d", "-o", "root", "-g", "root", "-m", "0755", "/usr/local/lib/wsprrypi"])
         install_file(git_root / "scripts" / "route_application.py",
                      Path("/usr/local/lib/wsprrypi/route_application.py"))
+        run(["sudo", "python3", str(git_root / "scripts" / "install_runtime_reconcile.py"), "install"])
         install_file(source, INSTALL_PATH)
     finally:
         if was_active:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7212,6 +7212,9 @@ manage_route_application() {
         install -d -o root -g root -m 0755 /usr/local/lib/wsprrypi || return 1
         install -o root -g root -m 0755 "${LOCAL_REPO_DIR}/scripts/route_application.py" \
             /usr/local/lib/wsprrypi/route_application.py || return 1
+        python3 "${LOCAL_REPO_DIR}/scripts/install_runtime_reconcile.py" install || return 1
+    elif [[ "$ACTION" == "uninstall" && "$DRY_RUN" != "true" ]]; then
+        python3 "${LOCAL_REPO_DIR}/scripts/install_runtime_reconcile.py" remove || return 1
     fi
 }
 

--- a/scripts/install_runtime_reconcile.py
+++ b/scripts/install_runtime_reconcile.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Install/remove the fixed application startup files with attributable retries."""
+import hashlib
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+
+import rp1_gpclk_dkms_install as installer
+import runtime_reconcile as recovery
+
+ROOT = Path(__file__).resolve().parents[1]
+STATE = Path('/var/lib/wsprrypi/rp1-startup-files.json')
+OWNER_UID = 0
+FILES = {
+    '/usr/local/lib/wsprrypi/runtime_reconcile.py': ('scripts/runtime_reconcile.py', 0o755),
+    '/usr/local/lib/wsprrypi/rp1_gpclk_dkms_install.py': ('scripts/rp1_gpclk_dkms_install.py', 0o755),
+    '/etc/systemd/system/wsprrypi-rp1-reconcile.service': ('systemd/wsprrypi-rp1-reconcile.service', 0o644),
+    '/etc/systemd/system/wsprrypi.service.d/92-rp1-reconcile.conf': ('systemd/92-rp1-reconcile.conf', 0o644),
+}
+
+
+def read(path):
+    for parent in path.parents:
+        if parent.exists():
+            info = parent.lstat()
+            if not stat.S_ISDIR(info.st_mode) or info.st_uid != OWNER_UID or info.st_mode & 0o022:
+                raise ValueError('unsafe startup integration directory: '+str(parent))
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return None
+    if not stat.S_ISREG(info.st_mode) or info.st_uid != OWNER_UID or info.st_mode & 0o022 or info.st_nlink != 1:
+        raise ValueError('unsafe startup integration file: '+str(path))
+    return path.read_bytes()
+
+
+def digest(data):
+    return None if data is None else hashlib.sha256(data).hexdigest()
+
+
+def apply(remove=False):
+    target = {name: None if remove else digest((ROOT/source).read_bytes())
+              for name, (source, unused) in FILES.items()}
+    raw = read(STATE)
+    record = recovery.strict_json(raw) if raw is not None else None
+    if record is not None:
+        if (set(record) != {'version', 'phase', 'before', 'after'} or
+                record['version'] != 1 or record['phase'] not in ('pending', 'complete') or
+                any(not isinstance(record[key], dict) or set(record[key]) != set(FILES)
+                    for key in ('before', 'after')) or
+                any(value is not None and (not isinstance(value, str) or not installer.SHA256.fullmatch(value))
+                    for key in ('before', 'after') for value in record[key].values())):
+            raise ValueError('invalid startup installation ownership record')
+        if record['phase'] == 'pending' and record['after'] != target:
+            raise ValueError('retry the exact pending startup installation first')
+    current = {name: digest(read(Path(name))) for name in FILES}
+    for name, actual in current.items():
+        allowed = ({None, target[name]} if record is None else
+                   {record['before'][name], record['after'][name]} if record['phase'] == 'pending' else
+                   {record['after'][name]})
+        if actual not in allowed:
+            raise ValueError('startup file differs from recorded ownership: '+name)
+    STATE.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+    installer.atomic_json(STATE, {'version': 1, 'phase': 'pending',
+                                  'before': current, 'after': target})
+    for name, (source, mode) in FILES.items():
+        path = Path(name)
+        if digest(read(path)) != current[name]:
+            raise ValueError('startup destination changed after planning: '+name)
+        if remove:
+            if path.exists(): path.unlink()
+        else:
+            path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+            fd, temporary = tempfile.mkstemp(prefix='.rp1-startup-', dir=path.parent)
+            try:
+                with os.fdopen(fd, 'wb') as stream:
+                    os.fchmod(stream.fileno(), mode)
+                    stream.write((ROOT/source).read_bytes())
+                    stream.flush()
+                    os.fsync(stream.fileno())
+                if digest(Path(temporary).read_bytes()) != target[name]:
+                    raise ValueError('startup source changed during installation')
+                os.replace(temporary, path)
+            finally:
+                if os.path.exists(temporary): os.unlink(temporary)
+        if path.parent.exists():
+            fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+            try: os.fsync(fd)
+            finally: os.close(fd)
+    subprocess.run(['/usr/bin/systemctl', 'daemon-reload'], check=True)
+    installer.atomic_json(STATE, {'version': 1, 'phase': 'complete',
+                                  'before': target, 'after': target})
+
+
+def install(remove=False):
+    if os.geteuid() != 0: raise ValueError('root required')
+    with recovery.Linux().lock():
+        apply(remove)
+
+
+if __name__ == '__main__':
+    try:
+        if sys.argv[1:] not in (['install'], ['remove']): raise ValueError('expected install or remove')
+        install(sys.argv[1] == 'remove')
+    except (OSError, ValueError, installer.ContractError, subprocess.SubprocessError) as error:
+        sys.exit(str(error))

--- a/scripts/rp1_gpclk_dkms_install.py
+++ b/scripts/rp1_gpclk_dkms_install.py
@@ -1803,8 +1803,12 @@ def recover_and_remove_owned_runtime(
                 )
                 provider = migration_provider
                 inspected = validate_readiness(runtime_call(
-                    runner, provider, "inspect", (), {"recovery_required"},
-                ), "recovery_required")
+                    runner, provider, "inspect", (),
+                    {"recovery_required", "activation_required"},
+                ))
+                require(inspected.get("result") in
+                        {"recovery_required", "activation_required"},
+                        "migration provider did not recognize inactive prior-boot state")
                 candidate_binding = inspected.get("identities", {}).get(
                     "installedBinding", {})
                 require(

--- a/scripts/runtime_reconcile.py
+++ b/scripts/runtime_reconcile.py
@@ -240,6 +240,8 @@ def reconcile(system):
             journal = journal_of(inspected)
             if journal is None or journal['plan']['bootId'] == boot:
                 return 'no-reboot-reconciliation'
+            require(inspected.get('result') == 'activation_required',
+                    'provider refuses reboot activation: '+str(inspected.get('result')))
             planned = system.call('activation-plan')
             plan = planned.get('activationPlan', {})
             digest = plan.get('planSha256')

--- a/scripts/runtime_reconcile.py
+++ b/scripts/runtime_reconcile.py
@@ -57,6 +57,11 @@ class Linux:
     def __init__(self):
         self.runner = installer.Runner(False)
 
+    def bootstrap_capable(self):
+        companion.inspect_service()
+        require(b'WSPRRYPI_RP1_REBOOT_IDLE' in companion.trusted(companion.BINARY)[0],
+                'application lacks separate reboot-idle startup support')
+
     def ownership(self):
         if not OWNERSHIP.exists() and not OWNERSHIP.is_symlink():
             return None
@@ -77,8 +82,6 @@ class Linux:
         for path, expected in {**binding['files'], **binding['externalFiles']}.items():
             require(installer.sha256_bytes(companion.trusted(Path(path))[0]) == expected,
                     'bound runtime file changed: '+path)
-        require(b'WSPRRYPI_RP1_REBOOT_IDLE' in companion.trusted(companion.BINARY)[0],
-                'application lacks separate reboot-idle startup support')
         return record
 
     def boot(self):
@@ -170,6 +173,18 @@ def journal_of(value):
 
 
 def prepare(system):
+    """Keep the application available and idle while provider state is unavailable."""
+    system.bootstrap_capable()
+    try:
+        prepare_environment(system)
+    except (OSError, ValueError, KeyError, TypeError, installer.ContractError) as error:
+        # Inverse deployment removes the binding before restoring the service.
+        # Unproven provider state must block administration, not its diagnostics UI.
+        system.environment(True)
+        print('RP1 provider unavailable; starting application idle: '+str(error), file=sys.stderr)
+
+
+def prepare_environment(system):
     """Set only the startup idle environment; inspection does not retire records."""
     record = system.ownership()
     if record is None or system.configuration()['backend'] != 'rp1-gpclk':

--- a/scripts/runtime_reconcile.py
+++ b/scripts/runtime_reconcile.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Application-owned, idle-only RP1 reboot reconciliation through public plans.
+
+The worker runs in its own systemd service because provider activation stops and
+restarts WsprryPi. Provider journals prove history, never persisted route policy.
+"""
+import contextlib
+import fcntl
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+
+import route_application as companion
+import rp1_gpclk_dkms_install as installer
+
+OWNERSHIP = Path('/var/lib/wsprrypi/rp1-gpclk-dkms-installation.json')
+CHECKPOINT = Path('/var/lib/wsprrypi/rp1-runtime-reconcile.json')
+ENVIRONMENT = Path('/run/wsprrypi-rp1/startup.env')
+LOCK = Path('/run/lock/wsprrypi-rp1-reconcile.lock')
+BINDING = Path('/etc/rp1-gpclk-dkms/runtime-controller.json')
+SCHEMA = 'wsprrypi-rp1-reboot-reconcile-v1'
+require = installer.require
+
+
+def strict_json(data):
+    def pairs(items):
+        result = {}
+        for key, value in items:
+            require(key not in result, 'duplicate JSON key')
+            result[key] = value
+        return result
+    return json.loads(data, object_pairs_hook=pairs)
+
+
+def validate_checkpoint(value):
+    require(isinstance(value, dict) and set(value) ==
+        {'schema', 'bootId', 'bindingSha256', 'route', 'activationPlanSha256', 'phase'},
+        'invalid reboot reconciliation checkpoint')
+    require(value['schema'] == SCHEMA and value['phase'] in ('pending', 'complete'),
+            'unsupported reboot reconciliation checkpoint')
+    uuid.UUID(value['bootId'])
+    require(value['route'] in (None, 'gpio4', 'gpio20'), 'invalid saved reboot route')
+    for name in ('bindingSha256', 'activationPlanSha256'):
+        require(isinstance(value[name], str) and installer.SHA256.fullmatch(value[name]),
+                'invalid reboot checkpoint identity')
+    return value
+
+
+class Linux:
+    def __init__(self):
+        self.runner = installer.Runner(False)
+
+    def ownership(self):
+        if not OWNERSHIP.exists() and not OWNERSHIP.is_symlink():
+            return None
+        strict_json(companion.trusted(OWNERSHIP)[0])
+        record, unused, reason = installer.load_ownership_record(OWNERSHIP)
+        require(record is not None, 'cannot prove provider ownership: '+str(reason))
+        if record['schema'] != installer.RUNTIME_RECORD_SCHEMA:
+            return None
+        raw, unused = companion.trusted(BINDING)
+        binding = strict_json(raw)
+        runtime = record['runtime']
+        require(installer.sha256_bytes(raw) == runtime['bindingSha256'] and
+                binding['sourceCommit'] == runtime['sourceCommit'] and
+                binding['artifactSetSha256'] == runtime['artifactSetSha256'] and
+                binding['kernel'] == os.uname().release,
+                'runtime binding differs from application ownership')
+        # Authenticate code and imports before invoking the privileged facade.
+        for path, expected in {**binding['files'], **binding['externalFiles']}.items():
+            require(installer.sha256_bytes(companion.trusted(Path(path))[0]) == expected,
+                    'bound runtime file changed: '+path)
+        require(b'WSPRRYPI_RP1_REBOOT_IDLE' in companion.trusted(companion.BINARY)[0],
+                'application lacks separate reboot-idle startup support')
+        return record
+
+    def boot(self):
+        return Path('/proc/sys/kernel/random/boot_id').read_text().strip()
+
+    def activation_journal(self, name='activation.json'):
+        try:
+            raw = companion.trusted(Path('/var/lib/rp1-gpclk-dkms/runtime-admin') / name)[0]
+        except FileNotFoundError:
+            return None
+        return strict_json(raw)
+
+    def configuration(self):
+        parsed = companion.configuration(companion.trusted(companion.CONFIG)[0])
+        return {'backend': parsed.get('Operation', 'Transmit Backend').lower(),
+                'route': 'gpio'+str(parsed.getint('GPIO', 'Transmit Pin')),
+                'transmit': parsed.getboolean('Operation', 'Transmit')}
+
+    def checkpoint(self):
+        try:
+            raw, info = companion.trusted(CHECKPOINT)
+        except FileNotFoundError:
+            return None
+        require(stat.S_IMODE(info.st_mode) == 0o600 and info.st_nlink == 1,
+                'unsafe reboot checkpoint')
+        return validate_checkpoint(strict_json(raw))
+
+    def save(self, value):
+        self.checkpoint()  # Refuse to replace foreign or malformed evidence.
+        installer.secure_record_parent(CHECKPOINT)
+        installer.atomic_json(CHECKPOINT, validate_checkpoint(value))
+
+    def call(self, operation, arguments=()):
+        value = installer.runtime_call(self.runner, installer.RUNTIME_PROVIDER,
+            operation, arguments, {'activation_required', 'neutral_ready', 'exact_ready',
+                                  'recovery_required', 'conflict'})
+        require(value.get('contract') == installer.RUNTIME_READINESS_CONTRACT,
+                'provider readiness contract differs')
+        return value
+
+    def service(self):
+        raw = subprocess.check_output(['/usr/bin/systemctl', 'show', 'wsprrypi.service',
+            '--property=ActiveState,LoadState,UnitFileState'], text=True, timeout=10)
+        return dict(line.split('=', 1) for line in raw.splitlines())
+
+    def environment(self, idle):
+        # systemd creates this root-owned RuntimeDirectory before ExecStartPre.
+        companion.trusted(Path(__file__))
+        installer.secure_record_parent(ENVIRONMENT)
+        if ENVIRONMENT.exists() or ENVIRONMENT.is_symlink():
+            companion.trusted(ENVIRONMENT)
+        fd, name = tempfile.mkstemp(prefix='.startup-', dir=ENVIRONMENT.parent)
+        try:
+            with os.fdopen(fd, 'wb') as stream:
+                os.fchmod(stream.fileno(), 0o600)
+                stream.write(b'WSPRRYPI_RP1_REBOOT_IDLE=1\n' if idle else b'')
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(name, ENVIRONMENT)
+        finally:
+            if os.path.exists(name): os.unlink(name)
+
+    @contextlib.contextmanager
+    def lock(self):
+        fd = os.open(LOCK, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+        try:
+            info = os.fstat(fd)
+            require(stat.S_ISREG(info.st_mode) and info.st_uid == 0 and
+                    stat.S_IMODE(info.st_mode) == 0o600 and info.st_nlink == 1,
+                    'unsafe reconciliation lock')
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            yield
+        finally:
+            os.close(fd)
+
+
+def bound_inspection(system, record):
+    value = system.call('inspect')
+    identity = value.get('identities', {}).get('installedBinding', {})
+    require(identity.get('status') == 'valid' and
+            identity.get('sha256') == record['runtime']['bindingSha256'] and
+            identity.get('value', {}).get('artifactSetSha256') == record['runtime']['artifactSetSha256'],
+            'provider inspection differs from owned installation')
+    return value
+
+
+def journal_of(value):
+    return value.get('activation', {}).get('value', {}).get('activationJournal')
+
+
+def prepare(system):
+    """Set only the startup idle environment; inspection does not retire records."""
+    record = system.ownership()
+    if record is None or system.configuration()['backend'] != 'rp1-gpclk':
+        system.environment(False)
+        return
+    # Never query the socket here: this runs while the provider may be
+    # waiting for systemctl start with its mutation lock held.
+    journal = system.activation_journal()
+    checkpoint = system.checkpoint()
+    pending = bool(checkpoint and checkpoint['phase'] == 'pending')
+    historical = bool(journal and journal['plan']['bootId'] != system.boot())
+    application = system.activation_journal('application.json')
+    current_route_restoration = bool(application and application.get('boot') == system.boot() and
+        application.get('phase') in ('configure-intent', 'start-intent', 'restored', 'stopped', 'administrator-masked'))
+    neutral_activation = bool(journal and journal.get('phase') == 'application-restore-intent')
+    system.environment(historical or neutral_activation or (pending and not current_route_restoration))
+
+
+def selected_history(plan, route):
+    require(plan.get('version') == 3 and plan.get('activationContext') == 'post-reboot',
+            'provider lacks supported terminal reboot reconciliation')
+    tx = plan['rebootEvidence']['transactions']['transaction.json']
+    if tx is None or tx['phase'] == 'recovered-inhibited':
+        return None
+    require(tx['phase'] == 'complete-inhibited' and
+            {1: 'gpio4', 2: 'gpio20'}.get(tx['target']) == route,
+            'persisted route differs from completed prior-boot selection')
+    return route
+
+
+def reconcile(system):
+    with system.lock():
+        record = system.ownership()
+        config = system.configuration()
+        if record is None or config['backend'] != 'rp1-gpclk':
+            return 'not-applicable'
+        boot = system.boot()
+        checkpoint = system.checkpoint()
+        if checkpoint and checkpoint['bootId'] == boot and checkpoint['phase'] == 'complete':
+            return 'already-complete'
+        if checkpoint and checkpoint['phase'] == 'pending':
+            require(checkpoint['bootId'] == boot and
+                    checkpoint['bindingSha256'] == record['runtime']['bindingSha256'],
+                    'interrupted reboot reconciliation belongs to another boot or installation')
+        service = system.service()
+        require(service.get('ActiveState') == 'active' and
+                service.get('LoadState') == 'loaded' and
+                service.get('UnitFileState') not in ('masked', 'masked-runtime'),
+                'reconciliation preserves stopped or administrator-masked application')
+        require(config['transmit'] is False, 'reboot reconciliation requires disabled output')
+        inspected = bound_inspection(system, record)
+        if checkpoint is None or checkpoint['bootId'] != boot:
+            journal = journal_of(inspected)
+            if journal is None or journal['plan']['bootId'] == boot:
+                return 'no-reboot-reconciliation'
+            planned = system.call('activation-plan')
+            plan = planned.get('activationPlan', {})
+            digest = plan.get('planSha256')
+            body = {key: value for key, value in plan.items() if key != 'planSha256'}
+            require(digest == installer.sha256_bytes(installer.canonical(body)),
+                    'activation plan digest differs')
+            route = selected_history(plan, config['route'])
+            require(plan['bootId'] == boot and plan['bindingSha256'] == record['runtime']['bindingSha256'],
+                    'activation plan differs from current owned boot')
+            checkpoint = {'schema': SCHEMA, 'bootId': boot,
+                'bindingSha256': plan['bindingSha256'], 'route': route,
+                'activationPlanSha256': digest, 'phase': 'pending'}
+            system.save(checkpoint)
+        require(checkpoint['route'] in (None, config['route']),
+                'persisted route changed during reboot reconciliation')
+        if inspected.get('result') == 'activation_required':
+            planned = system.call('activation-plan').get('activationPlan', {})
+            require(planned.get('planSha256') == checkpoint['activationPlanSha256'],
+                    'reboot activation plan changed; preserve checkpoint')
+            response = system.call('activation-ensure',
+                ['--plan-sha256', checkpoint['activationPlanSha256']])
+            require(response.get('operation') == 'activation-ensure' and
+                    response.get('response', {}).get('status') in ('activated-neutral', 'idempotent-no-change'),
+                    'neutral reboot activation did not complete')
+            inspected = bound_inspection(system, record)
+        journal = journal_of(inspected)
+        require(journal and journal.get('planSha256') == checkpoint['activationPlanSha256'] and
+                journal['phase'] == 'complete-neutral' and journal['plan']['bootId'] == boot,
+                'current runtime does not descend from reviewed reboot activation')
+        require(inspected.get('result') in ('neutral_ready', 'exact_ready'),
+                'runtime requires explicit recovery; preserve its evidence')
+        if checkpoint['route'] is not None:
+            current = system.configuration()
+            require(current == config, 'application route or output changed during recovery')
+            route = checkpoint['route']
+            args = ['--route', route, '--requested-route', route,
+                    '--configured-route', route, '--persisted-route', route]
+            planned = system.call('route-plan', args)
+            plan = planned.get('routePlan', {})
+            digest = plan.get('planSha256')
+            body = {key: value for key, value in plan.items() if key != 'planSha256'}
+            require(digest == installer.sha256_bytes(installer.canonical(body)) and
+                    plan.get('bindingSha256') == checkpoint['bindingSha256'] and
+                    plan.get('route') == route,
+                    'route plan differs from saved selection')
+            response = system.call('route-ensure', [*args, '--plan-sha256', digest])
+            require(response.get('response', {}).get('status') in ('restored', 'stopped',
+                    'administrator-masked', 'idempotent-ready'), 'route restoration did not complete')
+            final = system.call('inspect', args[2:])
+            require(final.get('result') == 'exact_ready' and
+                    final.get('routes', {}).get('active') == route and
+                    final.get('safety', {}).get('owner') is False and
+                    final.get('safety', {}).get('lease') is False,
+                    'restored route is not ready and unowned')
+        require(system.configuration()['transmit'] is False, 'application enabled output during recovery')
+        system.save(dict(checkpoint, phase='complete'))
+        return 'reconciled-idle'
+
+
+def main():
+    require(os.geteuid() == 0, 'root required')
+    require(sys.argv[1:] in (['prepare'], ['reconcile']), 'expected prepare or reconcile')
+    system = Linux()
+    if sys.argv[1] == 'prepare':
+        prepare(system)
+    else:
+        # Type=simple starts before application config loading; wait only for
+        # the existing idle startup override to take effect, never edit policy.
+        for attempt in range(40):
+            if system.configuration()['transmit'] is False:
+                break
+            time.sleep(0.25)
+        print(reconcile(system))
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except (OSError, ValueError, KeyError, TypeError, installer.ContractError,
+            subprocess.SubprocessError) as error:
+        sys.exit('RP1 startup recovery refused: '+str(error))

--- a/scripts/tests/route_application_test.py
+++ b/scripts/tests/route_application_test.py
@@ -104,7 +104,7 @@ class Tests(unittest.TestCase):
         function = source.split('manage_route_application() {', 1)[1].split('\n}\n', 1)[0]
         function = 'manage_route_application() {'+function+'\n}\n'
         for dry_run in ('true', 'false'):
-            script = ('install() { printf "%s\\n" "$*"; }\n'+function+
+            script = ('python3() { printf "%s\\n" "$*"; }\n'+'install() { printf "%s\\n" "$*"; }\n'+function+
                 'ACTION=install\nLOCAL_REPO_DIR=/selected-checkout\nDRY_RUN='+dry_run+
                 '\nmanage_route_application\n')
             result = subprocess.check_output(['bash', '-c', script], text=True, cwd='/tmp')

--- a/scripts/tests/rp1_gpclk_dkms_install_test.py
+++ b/scripts/tests/rp1_gpclk_dkms_install_test.py
@@ -2629,6 +2629,12 @@ class ApplyPolicyTests(unittest.TestCase):
         preserve.assert_called_once_with(record, "before-retirement")
 
     def test_owned_cross_boot_route_journals_use_reviewed_candidate_retirement(self):
+        self.check_candidate_retirement("recovery_required")
+
+    def test_owned_cross_boot_migration_accepts_candidate_reboot_admission(self):
+        self.check_candidate_retirement("activation_required")
+
+    def check_candidate_retirement(self, candidate_result):
         installed = self.root / "installed/runtime_provider.py"
         installed.parent.mkdir(parents=True)
         installed.write_text("# installed provider without journal retirement\n")
@@ -2682,12 +2688,16 @@ class ApplyPolicyTests(unittest.TestCase):
         removed = {"contract": MOD.RUNTIME_READINESS_CONTRACT,
             "operation": "remove", "planSha256": removal_digest,
             "response": {"status": "removed-exact-deployment"}}
-        replies = iter((base, base, retirement, retired, removable, removal, removed))
+        admitted = dict(base, result=candidate_result, state=candidate_result)
+        replies = iter((base, admitted, retirement, retired, removable, removal, removed))
         providers = []
         def runtime_call(unused_runner, provider_arg, operation,
                          arguments=(), allowed_results=()):
             providers.append((operation, provider_arg))
-            return next(replies)
+            value = next(replies)
+            if operation == "inspect" and provider_arg == candidate:
+                self.assertIn(value["result"], allowed_results)
+            return value
         identity = mock.Mock(st_dev=1, st_ino=2)
         with mock.patch.object(MOD, "RUNTIME_PROVIDER", installed), \
              mock.patch.object(MOD, "runtime_call", side_effect=runtime_call), \

--- a/scripts/tests/runtime_reconcile_test.py
+++ b/scripts/tests/runtime_reconcile_test.py
@@ -37,6 +37,7 @@ class System:
         self.active = None
         self.interrupt = None
 
+    def bootstrap_capable(self): pass
     def lock(self): return contextlib.nullcontext()
     def ownership(self): return copy.deepcopy(self.record)
     def configuration(self): return copy.deepcopy(self.config)
@@ -228,6 +229,19 @@ class Tests(unittest.TestCase):
                     installation.apply(remove=True)
                     self.assertTrue(all(not Path(p).exists() for p in targets))
                     self.assertTrue(all(call.args[0] == ['/usr/bin/systemctl', 'daemon-reload'] for call in command.call_args_list))
+
+    def test_provider_replacement_or_conflict_starts_diagnostics_idle_without_administration(self):
+        for error in (FileNotFoundError('binding retired'), recovery.installer.ContractError('ownership differs')):
+            system = System()
+            with patch.object(system, 'ownership', side_effect=error):
+                recovery.prepare(system)
+                self.assertTrue(system.env)
+                with self.assertRaises(type(error)): recovery.reconcile(system)
+            self.assertFalse(system.calls)
+        system = System()
+        with patch.object(system, 'bootstrap_capable', side_effect=ValueError('old binary')):
+            with self.assertRaises(ValueError): recovery.prepare(system)
+        self.assertIsNone(system.env)
 
     def test_duplicate_or_malformed_checkpoint_is_rejected(self):
         with self.assertRaises(recovery.installer.ContractError): recovery.strict_json('{"a":1,"a":2}')

--- a/scripts/tests/runtime_reconcile_test.py
+++ b/scripts/tests/runtime_reconcile_test.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Offline startup orchestration tests; fake public provider, no system effects."""
+import contextlib
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import runtime_reconcile as recovery
+
+
+def digest(value):
+    return recovery.installer.sha256_bytes(recovery.installer.canonical(value))
+
+
+class System:
+    def __init__(self, route='gpio4', history=True):
+        self.record = {'runtime': {'bindingSha256': 'a'*64, 'artifactSetSha256': 'b'*64}}
+        self.config = {'backend': 'rp1-gpclk', 'route': route, 'transmit': False}
+        self.saved = None
+        self.env = None
+        self.calls = []
+        self.state = 'activation_required'
+        self.service_state = {'LoadState': 'loaded', 'ActiveState': 'active', 'UnitFileState': 'enabled'}
+        self.current_boot = '00000000-0000-0000-0000-000000000002'
+        self.plan = {'version': 3, 'activationContext': 'post-reboot',
+            'bindingSha256': 'a'*64, 'artifactSetSha256': 'b'*64,
+            'bootId': self.current_boot, 'rebootEvidence': {'transactions': {
+                'transaction.json': {'phase': 'complete-inhibited', 'target': 1 if route == 'gpio4' else 2} if history else None}}}
+        self.plan_hash = digest(self.plan)
+        self.journal = {'phase': 'complete-neutral', 'plan': {'bootId': '00000000-0000-0000-0000-000000000001'}}
+        self.active = None
+        self.interrupt = None
+
+    def lock(self): return contextlib.nullcontext()
+    def ownership(self): return copy.deepcopy(self.record)
+    def configuration(self): return copy.deepcopy(self.config)
+    def checkpoint(self): return copy.deepcopy(self.saved)
+    def activation_journal(self, name='activation.json'):
+        return copy.deepcopy(self.journal) if name == 'activation.json' else None
+    def boot(self): return self.current_boot
+    def service(self): return copy.deepcopy(self.service_state)
+    def environment(self, idle): self.env = idle
+    def save(self, value):
+        self.saved = copy.deepcopy(value)
+        if self.interrupt == value['phase']: raise KeyboardInterrupt()
+    def call(self, operation, arguments=()):
+        self.calls.append((operation, tuple(arguments)))
+        if operation == 'inspect':
+            return {'result': self.state, 'identities': {'installedBinding': {
+                'status': 'valid', 'sha256': 'a'*64, 'value': {'artifactSetSha256': 'b'*64}}},
+                'activation': {'value': {'activationJournal': copy.deepcopy(self.journal)}},
+                'routes': {'active': self.active}, 'safety': {'owner': False, 'lease': False}}
+        if operation == 'activation-plan':
+            return {'activationPlan': dict(self.plan, planSha256=self.plan_hash)}
+        if operation == 'activation-ensure':
+            assert arguments == ['--plan-sha256', self.plan_hash]
+            self.journal = {'phase': 'complete-neutral', 'plan': copy.deepcopy(self.plan), 'planSha256': self.plan_hash}
+            self.state = 'neutral_ready'
+            if self.interrupt == operation: raise KeyboardInterrupt()
+            return {'operation': operation, 'response': {'status': 'activated-neutral'}}
+        if operation == 'route-plan':
+            body = {'route': self.config['route'], 'bindingSha256': 'a'*64}
+            return {'routePlan': dict(body, planSha256=digest(body))}
+        if operation == 'route-ensure':
+            assert arguments[:8] == ['--route', self.config['route'], '--requested-route', self.config['route'],
+                                     '--configured-route', self.config['route'], '--persisted-route', self.config['route']]
+            self.state = 'exact_ready'
+            self.active = self.config['route']
+            if self.interrupt == operation: raise KeyboardInterrupt()
+            return {'response': {'status': 'restored'}}
+        raise AssertionError(operation)
+
+
+class Tests(unittest.TestCase):
+    def test_normal_reboot_recovers_only_each_explicit_selected_route(self):
+        for route in ('gpio4', 'gpio20'):
+            with self.subTest(route=route):
+                system = System(route)
+                recovery.prepare(system)
+                self.assertTrue(system.env)
+                self.assertEqual(system.calls, [], 'ExecStartPre must never query the manager socket')
+                self.assertEqual(recovery.reconcile(system), 'reconciled-idle')
+                self.assertEqual(system.active, route)
+                self.assertEqual(system.saved['phase'], 'complete')
+                calls = copy.deepcopy(system.calls)
+                self.assertEqual(recovery.reconcile(system), 'already-complete')
+                self.assertEqual(system.calls, calls)
+                self.assertFalse(system.config['transmit'])
+
+    def test_neutral_reboot_and_completed_removal_do_not_select_a_route(self):
+        for removed in (False, True):
+            system = System(history=False)
+            if removed:
+                system.plan['rebootEvidence']['transactions']['transaction.json'] = {'phase': 'recovered-inhibited', 'target': 1}
+                system.plan_hash = digest(system.plan)
+            recovery.reconcile(system)
+            self.assertIsNone(system.active)
+            self.assertFalse(any(name.startswith('route-') for name, unused in system.calls))
+
+    def test_saved_route_mismatch_stopped_masked_and_transmission_are_preserved(self):
+        changes = (
+            lambda s: s.config.update(route='gpio20'),
+            lambda s: s.config.update(transmit=True),
+            lambda s: s.service_state.update(ActiveState='inactive'),
+            lambda s: s.service_state.update(LoadState='masked', UnitFileState='masked'),
+            lambda s: s.record['runtime'].update(bindingSha256='c'*64),
+            lambda s: setattr(s, 'plan_hash', '0'*64),
+            lambda s: s.plan.update(version=2),
+        )
+        for mutate in changes:
+            with self.subTest(mutate=mutate):
+                system = System(); mutate(system)
+                with self.assertRaises(recovery.installer.ContractError): recovery.reconcile(system)
+                self.assertFalse(any(name.endswith('-ensure') for name, unused in system.calls))
+
+    def test_each_worker_checkpoint_boundary_resumes_without_changing_route(self):
+        for route in ('gpio4', 'gpio20'):
+            for boundary in ('pending', 'activation-ensure', 'route-ensure', 'complete'):
+                with self.subTest(route=route, boundary=boundary):
+                    system = System(route); system.interrupt = boundary
+                    with self.assertRaises(KeyboardInterrupt): recovery.reconcile(system)
+                    recovery.prepare(system)
+                    system.interrupt = None
+                    recovery.reconcile(system)
+                    self.assertEqual(system.active, route)
+                    self.assertEqual(system.saved['phase'], 'complete')
+                    self.assertFalse(system.config['transmit'])
+
+    def test_checkpoint_never_adopts_new_boot_binding_route_or_failed_activation(self):
+        changes = (
+            lambda s: setattr(s, 'current_boot', '00000000-0000-0000-0000-000000000003'),
+            lambda s: s.record['runtime'].update(bindingSha256='c'*64),
+            lambda s: s.config.update(route='gpio20'),
+            lambda s: setattr(s, 'state', 'recovery_required'),
+        )
+        for mutate in changes:
+            with self.subTest(mutate=mutate):
+                system = System(); system.interrupt = 'pending'
+                with self.assertRaises(KeyboardInterrupt): recovery.reconcile(system)
+                system.interrupt = None; system.calls.clear(); mutate(system)
+                with self.assertRaises(recovery.installer.ContractError): recovery.reconcile(system)
+                self.assertFalse(any(name.endswith('-ensure') for name, unused in system.calls))
+
+    def test_alternate_backend_and_same_boot_neutral_do_not_select_route(self):
+        system = System(); system.config['backend'] = 'si5351'
+        self.assertEqual(recovery.reconcile(system), 'not-applicable')
+        self.assertFalse(system.calls)
+        system = System(); system.journal['plan']['bootId'] = system.boot()
+        self.assertEqual(recovery.reconcile(system), 'no-reboot-reconciliation')
+        self.assertFalse(any(name.endswith('-ensure') for name, unused in system.calls))
+
+    def test_preparation_preserves_boot_policy_and_requires_no_socket(self):
+        source = (Path(__file__).resolve().parents[2]/'src/config_handler.cpp').read_text()
+        override = source.split('if (std::getenv("WSPRRYPI_ROUTE_RESTORE_IDLE") != nullptr ||', 1)[1].split('switch (config.enable_on_boot)', 1)[0]
+        self.assertIn('WSPRRYPI_RP1_REBOOT_IDLE', override)
+        self.assertIn('config.transmit = false', override)
+        self.assertNotIn('config.enable_on_boot =', override)
+        for old in (True, False):
+            system = System(); system.config['transmit'] = old
+            recovery.prepare(system)
+            self.assertTrue(system.env)
+            self.assertEqual(system.config['transmit'], old)
+            self.assertFalse(system.calls)
+
+    def test_bootstrap_flag_does_not_hide_current_route_restoration_acknowledgement(self):
+        system = System(); system.interrupt = 'activation-ensure'
+        with self.assertRaises(KeyboardInterrupt): recovery.reconcile(system)
+        with patch.object(system, 'activation_journal', side_effect=lambda name='activation.json':
+                system.journal if name == 'activation.json' else {'boot': system.boot(), 'phase': 'start-intent'}):
+            recovery.prepare(system)
+        self.assertFalse(system.env)
+        source = (Path(__file__).resolve().parents[2]/'src/scheduling_runtime.cpp').read_text()
+        self.assertIn('restoration && std::getenv("WSPRRYPI_RP1_REBOOT_IDLE") == nullptr', source)
+        self.assertIn('!acknowledge_rp1_restoration(restoration, config.transmit)', source)
+
+    def test_two_reboots_each_require_new_boot_plan_and_route_request(self):
+        for route in ('gpio4', 'gpio20'):
+            system = System(route)
+            recovery.reconcile(system)
+            first = copy.deepcopy(system.saved)
+            system.current_boot = '00000000-0000-0000-0000-000000000003'
+            system.plan['bootId'] = system.current_boot
+            system.plan_hash = digest(system.plan)
+            system.state = 'activation_required'
+            system.active = None
+            recovery.prepare(system)
+            self.assertTrue(system.env)
+            recovery.reconcile(system)
+            self.assertNotEqual(first['activationPlanSha256'], system.saved['activationPlanSha256'])
+            self.assertNotEqual(first['bootId'], system.saved['bootId'])
+            self.assertEqual(system.active, route)
+
+    def test_startup_installer_upgrade_removal_and_interrupted_retry(self):
+        import install_runtime_reconcile as installation
+        for boundary in (None, 0, 1, 2):
+            with self.subTest(boundary=boundary), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                (root/'source').write_bytes(b'first')
+                targets = {str(root/('installed'+str(i))): ('source', 0o644) for i in range(3)}
+                state = root/'state.json'
+                def read(path): return path.read_bytes() if path.exists() else None
+                replace = installation.os.replace
+                calls = []
+                def interrupted(source, target):
+                    replace(source, target)
+                    if str(target) in targets:
+                        calls.append(str(target))
+                        if len(calls)-1 == boundary: raise KeyboardInterrupt()
+                with patch.object(installation, 'ROOT', root), patch.object(installation, 'STATE', state), \
+                     patch.object(installation, 'FILES', targets), patch.object(installation, 'read', read), \
+                     patch.object(installation.subprocess, 'run') as command:
+                    with patch.object(installation.os, 'replace', interrupted):
+                        if boundary is None: installation.apply()
+                        else:
+                            with self.assertRaises(KeyboardInterrupt): installation.apply()
+                    installation.apply()
+                    self.assertTrue(all(Path(p).read_bytes() == b'first' for p in targets))
+                    (root/'source').write_bytes(b'upgrade')
+                    installation.apply()
+                    self.assertTrue(all(Path(p).read_bytes() == b'upgrade' for p in targets))
+                    installation.apply(remove=True)
+                    installation.apply(remove=True)
+                    self.assertTrue(all(not Path(p).exists() for p in targets))
+                    self.assertTrue(all(call.args[0] == ['/usr/bin/systemctl', 'daemon-reload'] for call in command.call_args_list))
+
+    def test_duplicate_or_malformed_checkpoint_is_rejected(self):
+        with self.assertRaises(recovery.installer.ContractError): recovery.strict_json('{"a":1,"a":2}')
+        for value in ({}, {'schema': recovery.SCHEMA}):
+            with self.assertRaises(recovery.installer.ContractError): recovery.validate_checkpoint(value)
+
+
+if __name__ == '__main__': unittest.main()

--- a/scripts/tests/runtime_reconcile_test.py
+++ b/scripts/tests/runtime_reconcile_test.py
@@ -104,6 +104,16 @@ class Tests(unittest.TestCase):
             self.assertIsNone(system.active)
             self.assertFalse(any(name.startswith('route-') for name, unused in system.calls))
 
+    def test_blocked_history_reports_provider_refusal_without_planning(self):
+        for state in ('recovery_required', 'conflict'):
+            system = System()
+            system.state = state
+            with self.assertRaisesRegex(recovery.installer.ContractError,
+                                        'provider refuses reboot activation: '+state):
+                recovery.reconcile(system)
+            self.assertEqual([name for name, unused in system.calls], ['inspect'])
+            self.assertIsNone(system.saved)
+
     def test_saved_route_mismatch_stopped_masked_and_transmission_are_preserved(self):
         changes = (
             lambda s: s.config.update(route='gpio20'),

--- a/src/Makefile
+++ b/src/Makefile
@@ -1251,7 +1251,7 @@ semantics-test-portable:
 	$(Q)$(MAKE) --no-print-directory semantics-test-portable-profile \
 		BACKENDS=simulated ANCILLARY_GPIO=0 SUDO=
 
-semantics-test-portable-profile: i2c-bus-inventory-test i2c-bus-selection-test backend-capabilities-regression-test backend-capabilities-make-regression-test debug band-lookup-correlation-test chipset-offsets-test mailbox-memory-flag-test legacy-gpio-clock-model-test gpio-frequency-correction-test websocket-lifecycle-test web-server-network-lifecycle-test $(BIN_DIR)/$(UI_SOURCE_REGRESSION_TEST_OUT) $(BIN_DIR)/$(GPIO_BAND_POLICY_TEST_OUT)
+semantics-test-portable-profile: idle-startup-policy-test i2c-bus-inventory-test i2c-bus-selection-test backend-capabilities-regression-test backend-capabilities-make-regression-test debug band-lookup-correlation-test chipset-offsets-test mailbox-memory-flag-test legacy-gpio-clock-model-test gpio-frequency-correction-test websocket-lifecycle-test web-server-network-lifecycle-test $(BIN_DIR)/$(UI_SOURCE_REGRESSION_TEST_OUT) $(BIN_DIR)/$(GPIO_BAND_POLICY_TEST_OUT)
 	$(Q)echo "Running portable UI/source regression tests."
 	$(Q)./$(BIN_DIR)/$(UI_SOURCE_REGRESSION_TEST_OUT)
 	$(Q)echo "Running portable GPIO band fail-closed policy tests."
@@ -1621,6 +1621,7 @@ $(BIN_DIR)/$(RP1_GPCLK_ROUTE_SERVICE_TEST_OUT): tests/rp1_gpclk_route_service_te
 rp1-gpclk-route-service-test: $(BIN_DIR)/$(RP1_GPCLK_ROUTE_SERVICE_TEST_OUT)
 	$(Q)./$(BIN_DIR)/$(RP1_GPCLK_ROUTE_SERVICE_TEST_OUT)
 	$(Q)python3 ../scripts/tests/route_application_test.py
+	$(Q)python3 ../scripts/tests/runtime_reconcile_test.py
 
 $(BIN_DIR)/$(RP1_GPCLK_TRANSMIT_BACKEND_TEST_OUT): WSPR-Transmitter/src/rp1_gpclk_transmit_backend_test.cpp WSPR-Transmitter/src/rp1_gpclk_transmit_backend.cpp WSPR-Transmitter/src/rp1_gpclk_development_policy.cpp WSPR-Transmitter/src/rp1_gpclk_event_program.cpp WSPR-Transmitter/src/rp1_gpclk_backend.cpp WSPR-Transmitter/src/rp1_gpclk_linux_provider.cpp WSPR-Transmitter/src/rp1_gpclk_planner.cpp WSPR-Transmitter/src/rp1_gpclk_reconciliation.cpp Chipset-Offsets/src/chipset_offsets.hpp
 	$(Q)mkdir -p $(BIN_DIR)
@@ -1733,3 +1734,7 @@ $(BIN_DIR)/i2c_bus_inventory_test: tests/i2c_bus_inventory_test.cpp i2c_bus_inve
 
 i2c-bus-selection-test: $(BIN_DIR)/$(SEMANTICS_TEST_OUT)
 	$(Q)./$(BIN_DIR)/$(SEMANTICS_TEST_OUT) --i2c-bus-selection-only
+
+.PHONY: idle-startup-policy-test
+idle-startup-policy-test: $(BIN_DIR)/$(SEMANTICS_TEST_OUT)
+	$(Q)./$(BIN_DIR)/$(SEMANTICS_TEST_OUT) --idle-startup-overrides-only

--- a/src/config_handler.cpp
+++ b/src/config_handler.cpp
@@ -1686,7 +1686,8 @@ bool apply_enable_on_boot_startup_policy()
 {
     // A route restoration restarts the application, never its transmission.
     // This startup-only override leaves the saved boot preference unchanged.
-    if (std::getenv("WSPRRYPI_ROUTE_RESTORE_IDLE") != nullptr)
+    if (std::getenv("WSPRRYPI_ROUTE_RESTORE_IDLE") != nullptr ||
+        std::getenv("WSPRRYPI_RP1_REBOOT_IDLE") != nullptr)
     {
         config.transmit = false;
         config_to_json();

--- a/src/scheduling_runtime.cpp
+++ b/src/scheduling_runtime.cpp
@@ -869,7 +869,10 @@ bool wspr_loop()
         }
     }
 
-    if (const char *restoration = std::getenv("WSPRRYPI_ROUTE_RESTORE_IDLE"))
+    // Reboot bootstrap has no current route transaction to acknowledge. The
+    // separate worker restores the route and restarts us with its fresh token.
+    if (const char *restoration = std::getenv("WSPRRYPI_ROUTE_RESTORE_IDLE");
+        restoration && std::getenv("WSPRRYPI_RP1_REBOOT_IDLE") == nullptr)
     {
         const auto listener_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
         while (start_web && !webServer.isListening() &&

--- a/src/tests/dial_frequency_semantics_test.cpp
+++ b/src/tests/dial_frequency_semantics_test.cpp
@@ -661,8 +661,42 @@ void test_explicit_tone_experimental_policy()
 
 } // namespace
 
+void test_idle_startup_overrides()
+{
+    for (const char *flag : {"WSPRRYPI_ROUTE_RESTORE_IDLE", "WSPRRYPI_RP1_REBOOT_IDLE"})
+    {
+        setenv(flag, "offline-restoration", 1);
+        for (auto policy : {EnableOnBootBehavior::Never,
+                            EnableOnBootBehavior::Follow,
+                            EnableOnBootBehavior::Always})
+        {
+            init_default_config();
+            config.use_ini = true;
+            config.ini_filename = "/tmp/route_restoration_startup.ini";
+            write_text_file(config.ini_filename, "");
+            iniFile.set_filename(config.ini_filename);
+            config.enable_on_boot = policy;
+            config.transmit = true;
+            config_to_json();
+            json_to_ini();
+            apply_enable_on_boot_startup_policy();
+            require(!config.transmit &&
+                iniFile.getData().at("Operation").at("Transmit") == "false",
+                "Idle startup must disable and persist transmission for every boot policy");
+            require(config.enable_on_boot == policy,
+                "Idle startup must preserve the saved boot preference");
+        }
+        unsetenv(flag);
+    }
+}
+
 int main(int argc, char *argv[])
 {
+    if (argc == 2 && std::string(argv[1]) == "--idle-startup-overrides-only")
+    {
+        test_idle_startup_overrides();
+        return EXIT_SUCCESS;
+    }
     if (argc == 2 && std::string(argv[1]) == "--i2c-bus-selection-only")
     {
         init_config_json();
@@ -5000,18 +5034,7 @@ int main(int argc, char *argv[])
             "/tmp/enable_on_boot_startup_always.ini",
             "Enable on Boot Always must enable and persist Operation.Transmit on startup");
 
-        setenv("WSPRRYPI_ROUTE_RESTORE_IDLE", "offline-restoration", 1);
-        for (auto policy : {EnableOnBootBehavior::Never,
-                            EnableOnBootBehavior::Follow,
-                            EnableOnBootBehavior::Always})
-        {
-            exercise_startup_policy(policy, true, false,
-                "/tmp/route_restoration_startup.ini",
-                "Route restoration must persist idle startup for every boot policy");
-            require(config.enable_on_boot == policy,
-                "Route restoration must preserve the saved boot preference");
-        }
-        unsetenv("WSPRRYPI_ROUTE_RESTORE_IDLE");
+        test_idle_startup_overrides();
 
         auto exercise_managed_startup_gate =
             [](EnableOnBootBehavior behavior,

--- a/systemd/92-rp1-reconcile.conf
+++ b/systemd/92-rp1-reconcile.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+# Owned by WsprryPi startup orchestration.
+[Service]
+RuntimeDirectory=wsprrypi-rp1
+RuntimeDirectoryMode=0700
+EnvironmentFile=-/run/wsprrypi-rp1/startup.env
+ExecStartPre=/usr/bin/python3 /usr/local/lib/wsprrypi/runtime_reconcile.py prepare
+ExecStartPost=/usr/bin/systemctl --no-block start wsprrypi-rp1-reconcile.service

--- a/systemd/wsprrypi-rp1-reconcile.service
+++ b/systemd/wsprrypi-rp1-reconcile.service
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+[Unit]
+Description=Restore WsprryPi's selected RP1 route after reboot with output disabled
+After=wsprrypi.service
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/usr/bin/python3 /usr/local/lib/wsprrypi/runtime_reconcile.py reconcile
+TimeoutStartSec=180


### PR DESCRIPTION
Restore the saved RP1 route after a normal reboot through public provider activation and route plans. An application-owned systemd worker performs recovery outside the application service, while a separate startup flag keeps bootstrap idle without bypassing the new route's readiness acknowledgement.

Install and remove only owned startup files, preserve stopped/masked service intent, bind retry checkpoints to boot/provider/route identities, and accept the newer provider's safe reboot classification during exact-source migration. The provider implementation is in the corresponding RP1-GPCLK-DKMS main merge; no module source is vendored here.

Validation: portable semantics and focused startup/route checks passed, along with 122 installer, 13 reconciliation, 13 service-install and 9 companion tests. Exact-source application and DKMS builds passed on wspr5. Integration 8a91b46bb255e04b8eb10f9f28b18536790723e5 with provider 45fe23868022557b16d774e25f798e94b45a8bf1 passed two consecutive normal reboot recoveries for GPIO4 and two for GPIO20, all idle. Repeated reconciliation preserved a subsequent explicit GPIO4 selection. Adversarial findings were repaired and reassessed. No RF qualification is claimed.

Documentation Impact: application runtime/installation guidance and provider contracts were updated. The separate Wsprry_Pi_Docs operator page still needs the corresponding automatic idle reboot-recovery guidance.
